### PR TITLE
parse: add S.parseFloat and S.parseInt

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,6 +232,20 @@
     return hasOwnProperty_.call(obj, key) ? Just(obj[key]) : Nothing();
   });
 
+  //  parse  /////////////////////////////////////////////////////////////////
+
+  //  parseFloat_ :: String -> Maybe Number
+  var parseFloat_ = function(s) {
+    var n = parseFloat(s);
+    return n === n ? Just(n) : Nothing();
+  };
+
+  //  parseInt_ :: Number -> String -> Maybe Number
+  var parseInt_ = curry(function(radix, s) {
+    var n = parseInt(s, radix);
+    return n === n ? Just(n) : Nothing();
+  });
+
   //  exports  ///////////////////////////////////////////////////////////////
 
   var sanctuary = {
@@ -250,6 +264,8 @@
     fromMaybe: fromMaybe,
     last: last,
     or: or,
+    parseFloat: parseFloat_,
+    parseInt: parseInt_,
     tail: tail,
     then: then,
     toMaybe: toMaybe,

--- a/test/index.js
+++ b/test/index.js
@@ -533,3 +533,30 @@ describe('object', function() {
   });
 
 });
+
+describe('parse', function() {
+
+  describe('parseFloat', function() {
+
+    it('returns a Maybe', function() {
+      assert(S.parseFloat('12.34').equals(S.Just(12.34)));
+      assert(S.parseFloat('xxx').equals(S.Nothing()));
+    });
+
+  });
+
+  describe('parseInt', function() {
+
+    it('returns a Maybe', function() {
+      assert(S.parseInt(10, '42').equals(S.Just(42)));
+      assert(S.parseInt(16, '2A').equals(S.Just(42)));
+      assert(S.parseInt(10, 'xxx').equals(S.Nothing()));
+    });
+
+    it('is curried', function() {
+      assert(S.parseInt(10)('42').equals(S.Just(42)));
+    });
+
+  });
+
+});


### PR DESCRIPTION
`Maybe Number` better expresses the return type than `Number` (with NaN). See purescript/purescript-globals#5 for related discussion.
