### PR TITLE
maybe: add S.encase

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,17 @@
     return x == null ? Nothing() : Just(x);
   };
 
+  //  encase :: (* -> a) -> (* -> Maybe a)
+  var encase = function(f) {
+    return function() {
+      try {
+        return Just(f.apply(this, arguments));
+      } catch (err) {
+        return Nothing();
+      }
+    };
+  };
+
   //  either  ////////////////////////////////////////////////////////////////
 
   function Either() {
@@ -239,13 +250,7 @@
   });
 
   //  parseJson :: String -> Maybe *
-  var parseJson = function(s) {
-    try {
-      return Just(JSON.parse(s));
-    } catch (err) {
-      return Nothing();
-    }
-  };
+  var parseJson = encase(JSON.parse);
 
   //  exports  ///////////////////////////////////////////////////////////////
 
@@ -258,6 +263,7 @@
     Right: Right,
     at: at,
     either: either,
+    encase: encase,
     get: get,
     head: head,
     init: init,

--- a/test/index.js
+++ b/test/index.js
@@ -169,6 +169,40 @@ describe('maybe', function() {
 
   });
 
+  describe('encase', function() {
+
+    //  factorial :: Number -> Number
+    var factorial = function(n) {
+      if (n < 0) {
+        throw new Error('Cannot determine factorial of negative number');
+      } else if (n === 0) {
+        return 1;
+      } else {
+        return n * factorial(n - 1);
+      }
+    };
+
+    it('returns a function which returns a Just on success', function() {
+      assert(S.encase(factorial)(5).equals(S.Just(120)));
+    });
+
+    it('returns a function which returns a Nothing on failure', function() {
+      assert(S.encase(factorial)(-1).equals(S.Nothing()));
+    });
+
+    it('can be applied to a function of arbitrary arity', function() {
+      var f = S.encase(function(a, b, c, d, e) { return e; });
+      assert(f(1, 2, 3, 4, 5).equals(S.Just(5)));
+    });
+
+    it('preserves context', function() {
+      var f = S.encase(function() { return this; });
+      var ctx = {};
+      assert(f.call(ctx).equals(S.Just(ctx)));
+    });
+
+  });
+
 });
 
 describe('either', function() {


### PR DESCRIPTION
> __encase__
> _verb_
> enclose or cover in a case or close-fitting surround

As I imagine it we're _encasing_ a function which may explode in an indestructible wrapper. Alternative name suggestions welcome.
