### PR TITLE
control: add S.match

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -30,7 +30,6 @@
   "requireSpaceBetweenArguments": true,
   "requireSpacesInConditionalExpression": true,
   "requireSpacesInFunction": {"beforeOpeningCurlyBrace": true},
-  "requireTrailingComma": {"ignoreSingleLine": true},
   "validateLineBreaks": "LF",
   "validateQuoteMarks": {"escape": true, "mark": "'"}
 }


### PR DESCRIPTION
This is a slight variation on the function proposed in ramda/ramda#797. I realized that a special `_` value is unnecessary unless one wishes to accept `null` and `undefined`, since `Object` matches every other value. I also decided to support types which do not implement `expose`, though I'm not convinced this is a good idea.

I'm very keen to hear what others think of this idea in general and the approach I've taken specifically.
