### PR TITLE
add gets function and tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,6 +290,15 @@
     return hasOwnProperty_.call(obj, key) ? Just(obj[key]) : Nothing();
   });
 
+  //  gets :: [String] -> Object -> Maybe *
+  var gets = curry(function(keys, obj) {
+    var acc = Just(obj);
+    for (var idx = 0, len = keys.length; idx < len; idx += 1) {
+      acc = acc.chain(get(keys[idx]));
+    }
+    return acc;
+  });
+
   //  parse  /////////////////////////////////////////////////////////////////
 
   //  parseDate :: String -> Maybe Date
@@ -327,6 +336,7 @@
     encase: encase,
     find: find,
     get: get,
+    gets: gets,
     head: head,
     init: init,
     fromMaybe: fromMaybe,

--- a/test/index.js
+++ b/test/index.js
@@ -756,6 +756,18 @@ describe('object', function() {
 
   });
 
+  describe('gets', function() {
+
+    it('returns a Maybe', function() {
+      var obj = {x: {z: 0}, y: 42};
+      assert.deepEqual(S.fromMaybe({}, S.gets([], obj)), obj);
+      assert(S.gets(['y'], obj).equals(S.Just(42)));
+      assert(S.gets(['z'], obj).equals(S.Nothing()));
+      assert(S.gets(['x', 'z'], obj).equals(S.Just(0)));
+    });
+
+  });
+
 });
 
 describe('parse', function() {


### PR DESCRIPTION
`S.gets` allows one to do safe, nested property lookups. Nested property lookups are so common (and error prone) in JS that I think this would be a handy method to have around.
Compare the current method
```javascript
const obj = {foo: {bar: {baz: 'qux'}}};
const maybe_qux =  R.pipe(S.get('foo'),
  R.chain(S.get('bar')),
  R.chain(S.get('baz')))(obj)
```
with `S.gets`
```javascript
const maybe_qux = S.gets(['foo', 'bar', 'baz'], obj);
```
As far as implementation details, the non-reduce option is
```javascript
var gets = curry(function(keys, obj) {
  var acc = Just(obj)
  for (var idx = 0, len = keys.length; idx < len; idx += 1) {
    acc = acc.chain(get(keys[idx]));
  }
  return acc;
});
```
And `S.gets([], obj)` will return `S.Just(obj)`.