### PR TITLE
add Ramda dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Sanctuary
 
-Sanctuary is small functional programming library inspired by Haskell and
-PureScript. Sanctuary makes it possible to write safe code without null checks.
+Sanctuary is a small functional programming library inspired by Haskell and
+PureScript. It depends on and works nicely with [Ramda][1]. Sanctuary makes
+it possible to write safe code without null checks.
 
 In JavaScript it's trivial to introduce a possible run-time type error:
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "type": "git",
     "url": "git://github.com/plaid/sanctuary.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "ramda": "0.13.x"
+  },
   "devDependencies": {
     "istanbul": "0.3.x",
     "jscs": "1.10.x",


### PR DESCRIPTION
Recent discussion in #15 and #20 has made it apparent that Sanctuary should depend on Ramda, in addition to working nicely alongside it. We've so far duplicated two significant Ramda functions solely for internal use: `curry` and `arity`. As Sanctuary grows this list could easily expand to include `map`, [`toString`][1], and other functions I'd very much like to avoid duplicating.

Furthermore, every Ramda function supports the [`R.__`][2] placeholder thanks to [`R.curry`][3]. Sanctuary functions lack this useful characteristic. Sanctuary could, of course, provide its own placeholder value, but since Sanctuary is a companion to rather than a replacement for Ramda, reusing Ramda's placeholder value is a better option.


[1]: https://github.com/ramda/ramda/pull/924
[2]: http://ramdajs.com/docs/#__
[3]: http://ramdajs.com/docs/#curry
