### PR TITLE
maybe, either: define "toString"

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,11 @@
     return false;
   };
 
+  //  Nothing#toString :: -> String
+  Nothing.prototype.toString = function() {
+    return 'Nothing()';
+  };
+
   var Just = S.Just = function Just(value) {
     if (!(this instanceof Just)) {
       return new Just(value);
@@ -147,6 +152,11 @@
   //  Just#toBoolean :: -> Boolean
   Just.prototype.toBoolean = function() {
     return true;
+  };
+
+  //  Just#toString :: -> String
+  Just.prototype.toString = function() {
+    return 'Just(' + R.toString(this.value) + ')';
   };
 
   //  fromMaybe :: a -> Maybe a -> a
@@ -218,6 +228,11 @@
     return this;
   };
 
+  //  Left#toString :: -> String
+  Left.prototype.toString = function() {
+    return 'Left(' + R.toString(this.value) + ')';
+  };
+
   var Right = S.Right = function Right(value) {
     if (!(this instanceof Right)) {
       return new Right(value);
@@ -244,6 +259,11 @@
   //  Right#map :: (b -> c) -> Either a c
   Right.prototype.map = function(f) {
     return new Right(f(this.value));
+  };
+
+  //  Right#toString :: -> String
+  Right.prototype.toString = function() {
+    return 'Right(' + R.toString(this.value) + ')';
   };
 
   //  either :: (a -> c) -> (b -> c) -> Either a b -> c

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/plaid/sanctuary.git"
   },
   "dependencies": {
-    "ramda": "0.13.x"
+    "ramda": "0.14.x"
   },
   "devDependencies": {
     "istanbul": "0.3.x",

--- a/test/index.js
+++ b/test/index.js
@@ -168,6 +168,12 @@ describe('maybe', function() {
       eq(nothing.toBoolean(), false);
     });
 
+    it('provides a "toString" method', function() {
+      var nothing = S.Nothing();
+      eq(nothing.toString.length, 0);
+      eq(nothing.toString(), 'Nothing()');
+    });
+
     it('implements Semigroup', function() {
       var a = S.Nothing();
       var b = S.Nothing();
@@ -334,6 +340,12 @@ describe('maybe', function() {
       var just = S.Just(42);
       eq(just.toBoolean.length, 0);
       eq(just.toBoolean(), true);
+    });
+
+    it('provides a "toString" method', function() {
+      var just = S.Just([1, 2, 3]);
+      eq(just.toString.length, 0);
+      eq(just.toString(), 'Just([1, 2, 3])');
     });
 
     it('implements Semigroup', function() {
@@ -584,6 +596,12 @@ describe('either', function() {
       eq(left.map(square), left);
     });
 
+    it('provides a "toString" method', function() {
+      var left = S.Left('Cannot divide by zero');
+      eq(left.toString.length, 0);
+      eq(left.toString(), 'Left("Cannot divide by zero")');
+    });
+
     it('implements Functor', function() {
       var a = S.Left('Cannot divide by zero');
       var f = R.inc;
@@ -699,6 +717,12 @@ describe('either', function() {
       var right = S.Right(42);
       eq(right.map.length, 1);
       assert(right.map(square).equals(S.Right(1764)));
+    });
+
+    it('provides a "toString" method', function() {
+      var right = S.Right([1, 2, 3]);
+      eq(right.toString.length, 0);
+      eq(right.toString(), 'Right([1, 2, 3])');
     });
 
     it('implements Functor', function() {


### PR DESCRIPTION
This grants Maybe objects and Either objects the following property:

    eval(R.toString(x)) ≍ x

While this is primarily useful in the REPL, it also makes these values compatible with [`R.memoize`][1].

This change was made possible by ramda/ramda#924 and the publication of Ramda v0.14.0. I love it when a plan comes together. :grinning:


[1]: http://ramdajs.com/docs/#memoize
