### PR TITLE
maybe, either: give "equals" methods ES6 SameValue semantics

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@
 
   //  Just#equals :: Maybe a -> Boolean
   Just.prototype.equals = function(maybe) {
-    return maybe instanceof Just && maybe.value === this.value;
+    return maybe instanceof Just && R.eqProps('value', maybe, this);
   };
 
   //  Just#map :: (a -> b) -> Maybe b
@@ -225,7 +225,7 @@
 
   //  Left#equals :: Either a b -> Boolean
   Left.prototype.equals = function(either) {
-    return either instanceof Left && either.value === this.value;
+    return either instanceof Left && R.eqProps('value', either, this);
   };
 
   //  Left#map :: (b -> c) -> Either a c
@@ -268,7 +268,7 @@
 
   //  Right#equals :: Either a b -> Boolean
   Right.prototype.equals = function(either) {
-    return either instanceof Right && either.value === this.value;
+    return either instanceof Right && R.eqProps('value', either, this);
   };
 
   //  Right#map :: (b -> c) -> Either a c

--- a/test/index.js
+++ b/test/index.js
@@ -316,6 +316,11 @@ describe('maybe', function() {
       eq(just.equals(new S.Just(42)), true);
       eq(just.equals(S.Just(43)), false);
       eq(just.equals(S.Nothing()), false);
+
+      // SameValue semantics:
+      eq(S.Just(0).equals(S.Just(-0)), false);
+      eq(S.Just(-0).equals(S.Just(0)), false);
+      eq(S.Just(NaN).equals(S.Just(NaN)), true);
     });
 
     it('provides a "filter" method', function() {
@@ -593,6 +598,11 @@ describe('either', function() {
       eq(left.equals(new S.Left(42)), true);
       eq(left.equals(S.Left('42')), false);
       eq(left.equals(S.Right(42)), false);
+
+      // SameValue semantics:
+      eq(S.Left(0).equals(S.Left(-0)), false);
+      eq(S.Left(-0).equals(S.Left(0)), false);
+      eq(S.Left(NaN).equals(S.Left(NaN)), true);
     });
 
     it('provides a "map" method', function() {
@@ -738,6 +748,11 @@ describe('either', function() {
       eq(right.equals(new S.Right(42)), true);
       eq(right.equals(S.Right('42')), false);
       eq(right.equals(S.Left(42)), false);
+
+      // SameValue semantics:
+      eq(S.Right(0).equals(S.Right(-0)), false);
+      eq(S.Right(-0).equals(S.Right(0)), false);
+      eq(S.Right(NaN).equals(S.Right(NaN)), true);
     });
 
     it('provides a "map" method', function() {


### PR DESCRIPTION
[`Object.is`][1] and [`R.eq`][2] also have [SameValue][3] semantics. It's possible we should switch to [`R.eqDeep`][4] semantics, but we certainly don't want `===` semantics.


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
[2]: http://ramdajs.com/0.14/docs/#eq
[3]: http://people.mozilla.org/~jorendorff/es6-draft.html#sec-samevalue
[4]: http://ramdajs.com/0.14/docs/#eqDeep
