### PR TITLE
Add S.match function

### DIFF
--- a/index.js
+++ b/index.js
@@ -425,4 +425,21 @@
     return JSON.parse(s);
   });
 
+  //  regexp  ////////////////////////////////////////////////////////////////
+
+  //. match :: RegExp -> String -> Maybe [Maybe String]
+  //.
+  //. Takes a regular expression and tests it against the supplied string
+  //. returning a Nothing if there are no matches or a Just containing an
+  //. array of Maybe types corresponding to the matches found.
+  //.
+  //. ```javascript
+  //. > S.match(/abcd/, 'abcdefg')
+  //. Just([Just("abcd")])
+  //.
+  //. > S.match(/(good)?bye/, 'bye')
+  //. Just([Just("bye"), Nothing()])
+  //. ```
+  S.match = R.curry(R.compose(R.map(R.map(S.toMaybe)), S.toMaybe, R.match));
+
 }.call(this));

--- a/test/index.js
+++ b/test/index.js
@@ -1338,3 +1338,31 @@ describe('parse', function() {
   });
 
 });
+
+describe('regexp', function() {
+
+  describe('match', function() {
+
+    it('returns a Just containing an array of Justs', function() {
+      eq(S.match(/abcd/, 'abcdefg').toString(), 'Just([Just("abcd")])');
+    });
+
+    it('supports global patterns', function() {
+      eq(S.match(/[a-z]a/g, 'bananas').toString(),
+        'Just([Just("ba"), Just("na"), Just("na")])');
+    });
+
+    it('supports (optional) capturing groups', function() {
+      eq(S.match(/(good)?bye/, 'goodbye').toString(),
+        'Just([Just("goodbye"), Just("good")])');
+      eq(S.match(/(good)?bye/, 'bye').toString(),
+        'Just([Just("bye"), Nothing()])');
+    });
+
+    it('returns a Nothing() if no match', function() {
+      assert(S.match(/zzz/, 'abcdefg').equals(S.Nothing()));
+    });
+
+  });
+
+});


### PR DESCRIPTION
Resolves #28 . I've actually been using R.compose with Sanctuary to create a safe version of `R.match` quite a few times recently so I thought I'd have a stab at a PR for this. The implementation is simple enough:

```javascript
S.match = R.curry(function (regex, s) {
    return R.compose(S.toMaybe, R.match(regex))(s);
  });
```

But I was having problems writing the tests. Obviously because `R.match` returns an array, if I do something like:

```javascript
assert(S.match(/abcd/, 'abcdefg').equals(S.Just(['abcd']))
```

it fails because `Just.equals` is checking by reference.

If I do

```javascript
assert.deepEqual(S.match(/abcd/, str), S.Just(['abcd']));
```

it fails because `match` gives back this mad arraylike object with the object keys `input` and `index` so I find myself having to do this in the setup of the tests to get everything to work:

```javascript
var str = 'abcdefg';
var search = /abcd/;
var result = ['abcd'];
result.index = 0;
result.input = 'abcdefg';
...
assert.deepEqual(S.match(search, str), S.Just(result));
...
//etc
```

It feels a bit weird to do so but I'm not really able to think of alternatives. Any help would be appreciated.