### PR TITLE
list: document string support by S.indexOf, S.lastIndexOf, and S.slice

### DIFF
--- a/index.js
+++ b/index.js
@@ -876,10 +876,10 @@
   //. Accepts negative indices, which indicate an offset from the end of
   //. the list.
   //.
-  //. ```javascript
-  //. > S.slice(1, 1, ['a', 'b', 'c', 'd', 'e'])
-  //. Just([])
+  //. Dispatches to its third argument's `slice` method if present. As a
+  //. result, one may replace `[a]` with `String` in the type signature.
   //.
+  //. ```javascript
   //. > S.slice(1, 3, ['a', 'b', 'c', 'd', 'e'])
   //. Just(["b", "c"])
   //.
@@ -889,11 +889,11 @@
   //. > S.slice(2, -0, ['a', 'b', 'c', 'd', 'e'])
   //. Just(["c", "d", "e"])
   //.
-  //. > S.slice(0, 2, [])
-  //. Nothing()
-  //.
   //. > S.slice(1, 6, ['a', 'b', 'c', 'd', 'e'])
   //. Nothing()
+  //.
+  //. > S.slice(2, 6, 'banana')
+  //. Just("nana")
   //. ```
   var slice = S.slice = R.curry(function(start, end, xs) {
     var len = xs.length;
@@ -1057,11 +1057,21 @@
   //. of the first occurrence of the value in the list, if applicable;
   //. Nothing otherwise.
   //.
+  //. Dispatches to its second argument's `indexOf` method if present.
+  //. As a result, `String -> String -> Maybe Number` is an alternative
+  //. type signature.
+  //.
   //. ```javascript
   //. > S.indexOf('a', ['b', 'a', 'n', 'a', 'n', 'a'])
   //. Just(1)
   //.
   //. > S.indexOf('x', ['b', 'a', 'n', 'a', 'n', 'a'])
+  //. Nothing()
+  //.
+  //. > S.indexOf('an', 'banana')
+  //. Just(1)
+  //.
+  //. > S.indexOf('ax', 'banana')
   //. Nothing()
   //. ```
   S.indexOf = sanctifyIndexOf(R.indexOf);
@@ -1072,11 +1082,21 @@
   //. of the last occurrence of the value in the list, if applicable;
   //. Nothing otherwise.
   //.
+  //. Dispatches to its second argument's `lastIndexOf` method if present.
+  //. As a result, `String -> String -> Maybe Number` is an alternative
+  //. type signature.
+  //.
   //. ```javascript
   //. > S.lastIndexOf('a', ['b', 'a', 'n', 'a', 'n', 'a'])
   //. Just(5)
   //.
   //. > S.lastIndexOf('x', ['b', 'a', 'n', 'a', 'n', 'a'])
+  //. Nothing()
+  //.
+  //. > S.lastIndexOf('an', 'banana')
+  //. Just(3)
+  //.
+  //. > S.lastIndexOf('ax', 'banana')
   //. Nothing()
   //. ```
   S.lastIndexOf = sanctifyIndexOf(R.lastIndexOf);

--- a/test/index.js
+++ b/test/index.js
@@ -1116,6 +1116,13 @@ describe('list', function() {
       eq(S.slice(0, 5, [1, 2, 3, 4, 5]), S.Just([1, 2, 3, 4, 5]));
     });
 
+    it('can operate on strings', function() {
+      eq(S.slice(0, -0, 'ramda'), S.Just('ramda'));
+      eq(S.slice(1, -3, 'ramda'), S.Just('a'));
+      eq(S.slice(2, -3, 'ramda'), S.Just(''));
+      eq(S.slice(3, -3, 'ramda'), S.Nothing());
+    });
+
   });
 
   describe('head', function() {
@@ -1278,11 +1285,16 @@ describe('list', function() {
     });
 
     it('returns a Nothing if the element is not found', function() {
-      eq(S.indexOf(10, [1, 2, 3, 4, 5]), S.Nothing());
+      eq(S.indexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing());
     });
 
     it('returns Just the index of the element found', function() {
-      eq(S.indexOf(3, [1, 2, 3, 4, 5]), S.Just(2));
+      eq(S.indexOf('a', ['b', 'a', 'n', 'a', 'n', 'a']), S.Just(1));
+    });
+
+    it('can operate on strings', function() {
+      eq(S.indexOf('an', 'banana'), S.Just(1));
+      eq(S.indexOf('ax', 'banana'), S.Nothing());
     });
 
   });
@@ -1294,11 +1306,16 @@ describe('list', function() {
     });
 
     it('returns a Nothing if the element is not found', function() {
-      eq(S.lastIndexOf('d', ['a', 'b', 'b', 'c', 'c']), S.Nothing());
+      eq(S.lastIndexOf('x', ['b', 'a', 'n', 'a', 'n', 'a']), S.Nothing());
     });
 
     it('returns Just the last index of the element found', function() {
-      eq(S.lastIndexOf('c', ['a', 'b', 'b', 'c', 'c']), S.Just(4));
+      eq(S.lastIndexOf('a', ['b', 'a', 'n', 'a', 'n', 'a']), S.Just(5));
+    });
+
+    it('can operate on strings', function() {
+      eq(S.lastIndexOf('an', 'banana'), S.Just(3));
+      eq(S.lastIndexOf('ax', 'banana'), S.Nothing());
     });
 
   });


### PR DESCRIPTION
[`R.indexOf`][1] and [`R.lastIndexOf`][2] now dispatch thanks to ramda/ramda#1113. [`R.slice`][3] has dispatched in its current manner since [v0.8.0][4].


[1]: http://ramdajs.com/docs/#indexOf
[2]: http://ramdajs.com/docs/#lastIndexOf
[3]: http://ramdajs.com/docs/#slice
[4]: https://github.com/ramda/ramda/blob/v0.8.0/ramda.js#L3542
