### PR TITLE
extend: correct the behavior and add tests to check associativity

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,6 @@
   "strict": false,
   "maxparams": 99,
   "maxdepth": 99,
-  "maxstatements": 99,
   "maxcomplexity": 99,
   "asi": false,
   "boss": false,

--- a/index.js
+++ b/index.js
@@ -181,7 +181,8 @@
   //. The Maybe type represents optional values: a value of type `Maybe a` is
   //. either a Just whose value is of type `a` or a Nothing (with no value).
   //.
-  //. The Maybe type satisfies the [Monoid][] and [Monad][] specifications.
+  //. The Maybe type satisfies the [Monoid][], [Monad][], and [Extend][]
+  //. specifications.
   var Maybe = S.Maybe = function Maybe() {
     throw new Error('Cannot instantiate Maybe');
   };
@@ -309,6 +310,20 @@
   //. false
   //. ```
 
+  //# Maybe#extend :: Maybe a ~> (Maybe a -> a) -> Maybe a
+  //.
+  //. Takes a function and returns `this` if `this` is a Nothing; otherwise
+  //. it returns a Just whose value is the result of applying the function to
+  //. `this`.
+  //.
+  //. ```javascript
+  //. > S.Nothing().extend(function(x) { return x.value + 1; })
+  //. Nothing()
+  //.
+  //. > S.Just(42).extend(function(x) { return x.value + 1; })
+  //. Just(43)
+  //. ```
+
   //# Maybe#filter :: Maybe a ~> (a -> Boolean) -> Maybe a
   //.
   //. Takes a predicate and returns `this` if `this` is a Just whose value
@@ -335,8 +350,8 @@
   //. > S.Nothing().map(R.inc)
   //. Nothing()
   //.
-  //. > S.Just(42).map(R.inc)
-  //. Just(43)
+  //. > S.Just([1, 2, 3]).map(R.sum)
+  //. Just(6)
   //. ```
 
   //# Maybe#of :: Maybe a ~> b -> Maybe b
@@ -407,6 +422,9 @@
   //  Nothing#equals :: Maybe a ~> b -> Boolean
   Nothing.prototype.equals = def('Nothing#equals', [Any], R.is(Nothing));
 
+  //  Nothing#extend :: Maybe a ~> (Maybe a -> a) -> Maybe a
+  Nothing.prototype.extend = def('Nothing#extend', [Function], self);
+
   //  Nothing#map :: Maybe a ~> (a -> b) -> Maybe b
   Nothing.prototype.map = def('Nothing#map', [Function], self);
 
@@ -454,6 +472,11 @@
   //  Just#equals :: Maybe a ~> b -> Boolean
   Just.prototype.equals = def('Just#equals', [Any], function(x) {
     return x instanceof Just && R.eqProps('value', x, this);
+  });
+
+  //  Just#extend :: Maybe a ~> (Maybe a -> a) -> Maybe a
+  Just.prototype.extend = def('Just#extend', [Function], function(f) {
+    return Just(f(this));
   });
 
   //  Just#map :: Maybe a ~> (a -> b) -> Maybe b
@@ -530,7 +553,8 @@
   //. `Either a b` is either a Left whose value is of type `a` or a Right whose
   //. value is of type `b`.
   //.
-  //. The Either type satisfies the [Semigroup][] and [Monad][] specifications.
+  //. The Either type satisfies the [Semigroup][], [Monad][], and [Extend][]
+  //. specifications.
   var Either = S.Either = function Either() {
     throw new Error('Cannot instantiate Either');
   };
@@ -635,20 +659,17 @@
   //. false
   //. ```
 
-  //# Either#extend :: Either a b ~> (b -> b) -> Either a b
+  //# Either#extend :: Either a b ~> (Either a b -> b) -> Either a b
   //.
   //. Takes a function and returns `this` if `this` is a Left; otherwise it
   //. returns a Right whose value is the result of applying the function to
-  //. this Right's value. `Either#extend` is a restricted form of
-  //. [`Either#map`](#Either.prototype.map): the function provided must
-  //. return a value of the same type as its input (`Either#map` does not
-  //. have this restriction).
+  //. `this`.
   //.
   //. ```javascript
-  //. > S.Left('Cannot divide by zero').extend(R.inc)
+  //. > S.Left('Cannot divide by zero').extend(function(x) { return x.value + 1; })
   //. Left("Cannot divide by zero")
   //.
-  //. > S.Right(42).extend(R.inc)
+  //. > S.Right(42).extend(function(x) { return x.value + 1; })
   //. Right(43)
   //. ```
 
@@ -741,7 +762,7 @@
     return x instanceof Left && R.eqProps('value', x, this);
   });
 
-  //  Left#extend :: Either a b ~> (b -> b) -> Either a b
+  //  Left#extend :: Either a b ~> (Either a b -> b) -> Either a b
   Left.prototype.extend = def('Left#extend', [Function], self);
 
   //  Left#map :: Either a b ~> (b -> c) -> Either a c
@@ -791,9 +812,9 @@
     return x instanceof Right && R.eqProps('value', x, this);
   });
 
-  //  Right#extend :: Either a b ~> (b -> b) -> Either a b
+  //  Right#extend :: Either a b ~> (Either a b -> b) -> Either a b
   Right.prototype.extend = def('Right#extend', [Function], function(f) {
-    return Right(f(this.value));
+    return Right(f(this));
   });
 
   //  Right#map :: Either a b ~> (b -> c) -> Either a c
@@ -1320,6 +1341,7 @@
 
 }.call(this));
 
+//. [Extend]:       https://github.com/fantasyland/fantasy-land#extend
 //. [Monad]:        https://github.com/fantasyland/fantasy-land#monad
 //. [Monoid]:       https://github.com/fantasyland/fantasy-land#monoid
 //. [R.equals]:     http://ramdajs.com/docs/#equals

--- a/test/index.js
+++ b/test/index.js
@@ -150,6 +150,23 @@ describe('maybe', function() {
       eq(S.Nothing().equals(null), false);
     });
 
+    it('provides an "extend" method', function() {
+      eq(S.Nothing().extend.length, 1);
+      eq(S.Nothing().extend(function(x) { return x.value / 2; }), S.Nothing());
+
+      // associativity
+      var w = S.Nothing();
+      var f = function(x) { return x.value + 1; };
+      var g = function(x) { return x.value * x.value; };
+      eq(w.extend(g).extend(f),
+         w.extend(function(_w) { return f(_w.extend(g)); }));
+
+      assert.throws(function() { S.Nothing().extend([1, 2, 3]); },
+                    errorEq(TypeError,
+                            'Nothing#extend requires a value of type Function ' +
+                            'as its first argument; received [1, 2, 3]'));
+    });
+
     it('provides a "filter" method', function() {
       eq(S.Nothing().filter.length, 1);
       eq(S.Nothing().filter(R.T), S.Nothing());
@@ -345,6 +362,23 @@ describe('maybe', function() {
       eq(S.Just(new Number(42)).equals(S.Just(new Number(42))), true);
       eq(S.Just(new Number(42)).equals(42), false);
       // jshint +W053
+    });
+
+    it('provides an "extend" method', function() {
+      eq(S.Just(42).extend.length, 1);
+      eq(S.Just(42).extend(function(x) { return x.value / 2; }), S.Just(21));
+
+      // associativity
+      var w = S.Just(42);
+      var f = function(x) { return x.value + 1; };
+      var g = function(x) { return x.value * x.value; };
+      eq(w.extend(g).extend(f),
+         w.extend(function(_w) { return f(_w.extend(g)); }));
+
+      assert.throws(function() { S.Just(42).extend([1, 2, 3]); },
+                    errorEq(TypeError,
+                            'Just#extend requires a value of type Function ' +
+                            'as its first argument; received [1, 2, 3]'));
     });
 
     it('provides a "filter" method', function() {
@@ -660,6 +694,13 @@ describe('either', function() {
       eq(S.Left('abc').extend.length, 1);
       eq(S.Left('abc').extend(function(x) { return x / 2; }), S.Left('abc'));
 
+      // associativity
+      var w = S.Left('abc');
+      var f = function(x) { return x.value + 1; };
+      var g = function(x) { return x.value * x.value; };
+      eq(w.extend(g).extend(f),
+         w.extend(function(_w) { return f(_w.extend(g)); }));
+
       assert.throws(function() { S.Left('abc').extend([1, 2, 3]); },
                     errorEq(TypeError,
                             'Left#extend requires a value of type Function' +
@@ -834,7 +875,14 @@ describe('either', function() {
 
     it('provides an "extend" method', function() {
       eq(S.Right(42).extend.length, 1);
-      eq(S.Right(42).extend(function(x) { return x / 2; }), S.Right(21));
+      eq(S.Right(42).extend(function(x) { return x.value / 2; }), S.Right(21));
+
+      // associativity
+      var w = S.Right(42);
+      var f = function(x) { return x.value + 1; };
+      var g = function(x) { return x.value * x.value; };
+      eq(w.extend(g).extend(f),
+         w.extend(function(_w) { return f(_w.extend(g)); }));
 
       assert.throws(function() { S.Right('abc').extend([1, 2, 3]); },
                     errorEq(TypeError,


### PR DESCRIPTION
Added additional tests to check that the `extend` method satisfies the property laid out at https://github.com/fantasyland/fantasy-land#extend-method. Also fixes implementations to adhere to those specs.