### PR TITLE
extend: added support for lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -975,6 +975,31 @@
       Nothing();
   });
 
+  //# extend :: [a] -> ([a] -> a) -> [a]
+  //.
+  //. If the list has an extend method, then this dispatches to that.
+  //.
+  //. Takes a function that takes a list of `a`s and returns an `a` and
+  //. applies it to each slice of the list ending at the last element.
+  //.
+  //.
+  //. ```javascript
+  //. > S.extend([1, 2, 3], R.sum)
+  //. [6, 5, 3]
+  //. ```
+  S.extend =
+  def('List#extend', [Any, Function], function(list, f) {
+    if (typeof list.extend === 'function') {
+      return list.extend(f);
+    }
+
+    var result = [];
+    for (var idx = 0; idx < list.length; idx += 1) {
+      result.push(f(R.drop(idx, list)));
+    }
+    return result;
+  });
+
   //# at :: Number -> [a] -> Maybe a
   //.
   //. Takes an index and a list and returns Just the element of the list at

--- a/test/index.js
+++ b/test/index.js
@@ -1376,6 +1376,56 @@ describe('list', function() {
 
   });
 
+  describe('extend', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.extend, 'function');
+      eq(S.extend.length, 2);
+    });
+
+    it('curries its arguments', function() {
+      eq(typeof S.extend([1, 2, 3]), 'function');
+      eq(S.extend([1, 2, 3]).length, 1);
+
+      eq(typeof S.extend(R.__, R.sum), 'function');
+      eq(S.extend(R.__, R.sum).length, 1);
+    });
+
+    it('returns an empty list if applied to an empty list', function() {
+      eq(S.extend([], R.sum), []);
+    });
+
+    it('throws an exception when not given a function', function() {
+      assert.throws(function() { S.extend([], 'function'); },
+                    errorEq(TypeError,
+                            'List#extend requires a value of type Function' +
+                            ' as its second argument; received "function"'));
+    });
+
+    it('dispatches to inbuilt method if it exists', function() {
+      var arr = [1, 2, 3];
+      arr.extend = function(f) {
+        return [f(this)];
+      };
+      eq(S.extend(arr, R.sum), [6]);
+    });
+
+    it('works as expected on Numbers', function() {
+      eq(S.extend([1, 2, 3], R.sum), [6, 5, 3]);
+    });
+
+    it('is associative', function() {
+      var w = [1, 2, 3];
+      var f = R.sum;
+      var g = function(l) {
+        return l[0] !== undefined ? l[0] : -1;
+      };
+      eq(S.extend(S.extend(w, g), f),
+         S.extend(w, function(_w) { return f(S.extend(_w, g)); }));
+    });
+
+  });
+
   describe('head', function() {
 
     it('is a unary function', function() {


### PR DESCRIPTION
Lists now support the extend method. I've chosen to have the function apply in this form to a list, say `[1,2,3]`:
```
[ f [1, 2, 3], f [2, 3], f [3] ]
```
Thoughts @davidchambers and @benperez?