### PR TITLE
ramda@0.17.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -1406,9 +1406,9 @@
   //. > S.match(/(good)?bye/, 'bye')
   //. Just([Just("bye"), Nothing()])
   //. ```
-  S.match =
-  def('match', [RegExp, String],
-      R.compose(R.map(R.map(toMaybe)), toMaybe, R.match));
+  S.match = def('match', [RegExp, String], function(pattern, s) {
+    return R.map(R.map(toMaybe), toMaybe(s.match(pattern)));
+  });
 
 }.call(this));
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/plaid/sanctuary.git"
   },
   "dependencies": {
-    "ramda": "0.15.x"
+    "ramda": "0.17.x"
   },
   "devDependencies": {
     "istanbul": "0.3.x",


### PR DESCRIPTION
  - ramda/ramda#1277
  - ramda/ramda#1290

> :warning: `R.match` now returns `[]` rather than `null` when there are no matches ramda/ramda#1239
