### PR TITLE
actually call f in Nothing#chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,7 +491,7 @@
   Nothing.prototype.ap = def('Nothing#ap', [Maybe], self);
 
   //  Nothing#chain :: Maybe a ~> (a -> Maybe b) -> Maybe b
-  Nothing.prototype.chain = def('Nothing#chain', [Function], self);
+  Nothing.prototype.chain = def('Nothing#chain', [Function], function(f) { return f(this); });
 
   //  Nothing#concat :: Maybe a ~> Maybe a -> Maybe a
   Nothing.prototype.concat = def('Nothing#concat', [Maybe], R.identity);


### PR DESCRIPTION
Yo! I am not sure this is correct, but this is what lead me here:

```js
// pathEq :: [String] -> a -> b -> Boolean
let pathEq = function pathEq(path, val, obj) {
    return R.pipe(
        S.gets(path),
        R.chain(R.equals(val))
    )(obj);
};
let obj = { a: { b: 'x' } };
console.log(R.toString(pathEq(['a', 'b'], 'x', obj))); // => true
console.log(R.toString(pathEq(['a', 'b'], 'y', obj))); // => false
console.log(R.toString(pathEq(['a', 'c'], 'x', obj))); // => Nothing()
```

I expected that last line to output `false`. Because of how `Nothing#chain` was implemented, `R.equals` was never actually getting called when `S.gets` returned `Nothing`.

This commit is currently causing 2 tests to fail. Maybe that is okay and there are a couple other updates that should be part of this PR?

#### Test Fail 1, maybe Nothing implements Monad
`assert(a.chain(a.of).equals(a));`

Similarly to above, `a.of` was never actually getting called here. Now that `a.of` is getting called our assertion fails, but maybe `Nothing#of` needs a change (currently inherited from `Maybe#of`)

```js
console.log(R.toString(S.Nothing().of(7))); // => Just(7)
console.log(R.toString(S.Nothing().of(S.Nothing()))); // => Just(Nothing())
```
Is that the correct behavior?


#### Test Fail 2, maybe Nothing provides a "filter" method
`eq(S.Nothing().filter(R.T), S.Nothing());`

This is related because `Nothing#filter` is inherited from `Maybe#filter` which uses `chain`. If any of this is correct, we could fix by implementing `filter` on `Nothing`. I haven't investigated this one fully, figured I would submit the PR first for your review to see if I'm even on the right track. Thanks!