### PR TITLE
add maybeToEither

### DIFF
--- a/index.js
+++ b/index.js
@@ -972,6 +972,24 @@
     return either instanceof Left ? l(either.value) : r(either.value);
   });
 
+  //# maybeToEither :: a -> Maybe b -> Either a b
+  //.
+  //. Takes a value of any type and a Maybe, and returns an Either.
+  //. If the second argument is a Nothing, a Left containing the first
+  //. argument is returned. If the second argument is a Just, a Right
+  //. containing the Just's value is returned.
+  //.
+  //. ```javascript
+  //. > S.maybeToEither('Expecting an integer', S.parseInt(10, 'xyz'))
+  //. Left("Expecting an integer")
+  //.
+  //. > S.maybeToEither('Expecting an integer', S.parseInt(10, '42'))
+  //. Right(42)
+  //. ```
+  S.maybeToEither = def('maybeToEither', [a, Maybe], function(x, maybe) {
+    return maybe instanceof Nothing ? Left(x) : Right(maybe.value);
+  });
+
   //. ### Control
 
   var methodMissing = format('{repr} does not have {} {quote} method');

--- a/test/index.js
+++ b/test/index.js
@@ -1163,6 +1163,36 @@ describe('either', function() {
 
   });
 
+  describe('maybeToEither', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.either, 'function');
+      eq(S.maybeToEither.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.maybeToEither('left', 1); },
+                    errorEq(TypeError,
+                            '‘maybeToEither’ requires a value of type Maybe ' +
+                            'as its second argument; received 1'));
+    });
+
+    it('returns a Left of its first argument when the second is Nothing', function() {
+      eq(S.maybeToEither('error msg', S.Nothing()), S.Left('error msg'));
+    });
+
+    it('returns a Right of the value contained in the Just ' +
+       'when the second argument is a Just', function() {
+      eq(S.maybeToEither('error msg', S.Just(42)), S.Right(42));
+    });
+
+    it('is curried', function() {
+      eq(S.maybeToEither(0).length, 1);
+      eq(S.maybeToEither(0)(S.Just(42)), S.Right(42));
+    });
+
+  });
+
 });
 
 describe('control', function() {


### PR DESCRIPTION
I basically just followed the `either` tests except for the 'is curried' part, as I noticed it was quite extensive but none of the other 'is curried' tests were.

I decided against including "eitherIfElse" for now. I pretty much only created it because it seemed like a decent idea and you can use it to define `maybeToEither`. If you really like the idea of, I'm happy to submit a PR, but I figured I'd just let it hang out in my code for a while and see how much I actually use it.