### PR TITLE
maybe: add S.catMaybes

### DIFF
--- a/index.js
+++ b/index.js
@@ -682,9 +682,20 @@
   //. > S.maybe(0, R.length, S.Nothing())
   //. 0
   //. ```
-  S.maybe = def('maybe', [a, Function, Maybe], function(x, f, maybe) {
+  var maybe = S.maybe =
+  def('maybe', [a, Function, Maybe], function(x, f, maybe) {
     return fromMaybe(x, maybe.map(f));
   });
+
+  //# catMaybes :: [Maybe a] -> [a]
+  //.
+  //. Takes a list of Maybes and returns a list containing each Just's value.
+  //.
+  //. ```javascript
+  //. > S.catMaybes([S.Just('foo'), S.Nothing(), S.Just('baz')])
+  //. ["foo", "baz"]
+  //. ```
+  S.catMaybes = def('catMaybes', [Accessible], R.chain(maybe([], R.of)));
 
   //# encase :: (* -> a) -> (* -> Maybe a)
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -686,6 +686,30 @@ describe('maybe', function() {
 
   });
 
+  describe('catMaybes', function() {
+
+    it('is a unary function', function() {
+      eq(typeof S.catMaybes, 'function');
+      eq(S.catMaybes.length, 1);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.catMaybes(null); },
+                    errorEq(TypeError,
+                            'The first argument to ‘catMaybes’ ' +
+                            'cannot be null or undefined'));
+    });
+
+    it('returns a list containing the value of each Just', function() {
+      eq(S.catMaybes([]), []);
+      eq(S.catMaybes([S.Nothing(), S.Nothing()]), []);
+      eq(S.catMaybes([S.Nothing(), S.Just('b')]), ['b']);
+      eq(S.catMaybes([S.Just('a'), S.Nothing()]), ['a']);
+      eq(S.catMaybes([S.Just('a'), S.Just('b')]), ['a', 'b']);
+    });
+
+  });
+
   describe('encase', function() {
 
     it('is a unary function', function() {


### PR DESCRIPTION
Closes #72

`maybe :: b -> (a -> b) -> Maybe a -> b` proved useful in defining this function. I'll rebase this patch once #77 has been merged.
