### PR TITLE
maybe: add S.mapMaybe

### DIFF
--- a/index.js
+++ b/index.js
@@ -695,7 +695,25 @@
   //. > S.catMaybes([S.Just('foo'), S.Nothing(), S.Just('baz')])
   //. ["foo", "baz"]
   //. ```
-  S.catMaybes = def('catMaybes', [Accessible], R.chain(maybe([], R.of)));
+  var catMaybes = S.catMaybes =
+  def('catMaybes', [Accessible], R.chain(maybe([], R.of)));
+
+  //# mapMaybe :: (a -> Maybe b) -> [a] -> [b]
+  //.
+  //. Takes a function and a list, applies the function to each element of
+  //. the list, and returns a list of "successful" results. If the result of
+  //. applying the function to an element of the list is a Nothing, the result
+  //. is discarded; if the result is a Just, the Just's value is included in
+  //. the output list.
+  //.
+  //. In general terms, `mapMaybe` filters a list while mapping over it.
+  //.
+  //. ```javascript
+  //. > S.mapMaybe(S.head, [[], [1, 2, 3], [], [4, 5, 6], []])
+  //. [1, 4]
+  //. ```
+  S.mapMaybe =
+  def('mapMaybe', [Function, Accessible], R.compose(catMaybes, R.map));
 
   //# encase :: (* -> a) -> (* -> Maybe a)
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -710,6 +710,39 @@ describe('maybe', function() {
 
   });
 
+  describe('mapMaybe', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.mapMaybe, 'function');
+      eq(S.mapMaybe.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.mapMaybe([1, 2, 3]); },
+                    errorEq(TypeError,
+                            '‘mapMaybe’ requires a value of type Function ' +
+                            'as its first argument; received [1, 2, 3]'));
+
+      assert.throws(function() { S.mapMaybe(S.head, null); },
+                    errorEq(TypeError,
+                            'The second argument to ‘mapMaybe’ ' +
+                            'cannot be null or undefined'));
+    });
+
+    it('maps over a list to produce a list of successful results', function() {
+      eq(S.mapMaybe(S.head, []), []);
+      eq(S.mapMaybe(S.head, [[], [], []]), []);
+      eq(S.mapMaybe(S.head, [[1, 2], [3, 4], [5, 6]]), [1, 3, 5]);
+      eq(S.mapMaybe(S.head, [[1], [], [3], [], [5], []]), [1, 3, 5]);
+    });
+
+    it('is curried', function() {
+      eq(S.mapMaybe(S.head).length, 1);
+      eq(S.mapMaybe(S.head)(['foo', '', 'bar', '', 'baz']), ['f', 'b', 'b']);
+    });
+
+  });
+
   describe('encase', function() {
 
     it('is a unary function', function() {


### PR DESCRIPTION
Closes #73

`catMaybes :: [Maybe a] -> [a]` proved useful in defining this function. I'll rebase this patch once #78 has been merged.
