### PR TITLE
parse: disallow invalid characters in S.parseFloat

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -12,6 +12,7 @@
   "disallowSpacesInsideArrayBrackets": true,
   "disallowSpacesInsideObjectBrackets": true,
   "disallowSpacesInsideParentheses": true,
+  "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "disallowYodaConditions": true,
   "requireCapitalizedConstructors": true,

--- a/index.js
+++ b/index.js
@@ -1515,6 +1515,40 @@
     return d.valueOf() === d.valueOf() ? Just(d) : Nothing();
   });
 
+  //  requiredNonCapturingGroup :: [String] -> String
+  var requiredNonCapturingGroup = function(xs) {
+    return '(?:' + xs.join('|') + ')';
+  };
+
+  //  optionalNonCapturingGroup :: [String] -> String
+  var optionalNonCapturingGroup = function(xs) {
+    return requiredNonCapturingGroup(xs) + '?';
+  };
+
+  //  validFloatRepr :: String -> Boolean
+  var validFloatRepr = R.test(new RegExp(
+    '^' +                     // start-of-string anchor
+    '\\s*' +                  // any number of leading whitespace characters
+    '[+-]?' +                 // optional sign
+    requiredNonCapturingGroup([
+      'Infinity',             // "Infinity"
+      'NaN',                  // "NaN"
+      requiredNonCapturingGroup([
+        '[0-9]+',             // number
+        '[0-9]+[.][0-9]+',    // number with interior decimal point
+        '[0-9]+[.]',          // number with trailing decimal point
+        '[.][0-9]+'           // number with leading decimal point
+      ]) +
+      optionalNonCapturingGroup([
+        '[Ee]' +              // "E" or "e"
+        '[+-]?' +             // optional sign
+        '[0-9]+'              // exponent
+      ])
+    ]) +
+    '\\s*' +                  // any number of trailing whitespace characters
+    '$'                       // end-of-string anchor
+  ));
+
   //# parseFloat :: String -> Maybe Number
   //.
   //. Takes a string and returns Just the number represented by the string
@@ -1527,10 +1561,9 @@
   //. > S.parseFloat('foo.bar')
   //. Nothing()
   //. ```
-  S.parseFloat = def('parseFloat', [String], function(s) {
-    var n = parseFloat(s);
-    return n === n ? Just(n) : Nothing();
-  });
+  S.parseFloat =
+  def('parseFloat', [String],
+      R.pipe(Just, R.filter(validFloatRepr), R.map(parseFloat)));
 
   //# parseInt :: Integer -> String -> Maybe Integer
   //.

--- a/test/index.js
+++ b/test/index.js
@@ -2235,6 +2235,32 @@ describe('parse', function() {
       eq(S.parseFloat('12.34'), S.Just(12.34));
       eq(S.parseFloat('Infinity'), S.Just(Infinity));
       eq(S.parseFloat('-Infinity'), S.Just(-Infinity));
+      eq(S.parseFloat('NaN'), S.Just(NaN));
+      eq(S.parseFloat('-NaN'), S.Just(NaN));  // Haskell accepts "-NaN"
+      eq(S.parseFloat('0'), S.Just(0));
+      eq(S.parseFloat('-0'), S.Just(-0));
+      eq(S.parseFloat('42'), S.Just(42));
+      eq(S.parseFloat('42.'), S.Just(42));
+      eq(S.parseFloat('0.5'), S.Just(0.5));
+      eq(S.parseFloat('.25'), S.Just(0.25));
+      eq(S.parseFloat('+42'), S.Just(42));
+      eq(S.parseFloat('+42.'), S.Just(42));
+      eq(S.parseFloat('+0.5'), S.Just(0.5));
+      eq(S.parseFloat('+.25'), S.Just(0.25));
+      eq(S.parseFloat('-42'), S.Just(-42));
+      eq(S.parseFloat('-42.'), S.Just(-42));
+      eq(S.parseFloat('-0.5'), S.Just(-0.5));
+      eq(S.parseFloat('-.25'), S.Just(-0.25));
+      eq(S.parseFloat('0.5 '), S.Just(0.5));
+      eq(S.parseFloat(' 0.5'), S.Just(0.5));
+      eq(S.parseFloat('0.5x'), S.Nothing());  // parseFloat('0.5x') == 0.25
+      eq(S.parseFloat('x0.5'), S.Nothing());
+      eq(S.parseFloat('-1e3'), S.Just(-1000));
+      eq(S.parseFloat('-1e03'), S.Just(-1000));
+      eq(S.parseFloat('-1e+3'), S.Just(-1000));
+      eq(S.parseFloat('-1e+03'), S.Just(-1000));
+      eq(S.parseFloat('-1e-3'), S.Just(-0.001));
+      eq(S.parseFloat('-1e-03'), S.Just(-0.001));
       eq(S.parseFloat('xxx'), S.Nothing());
     });
 
@@ -2262,6 +2288,7 @@ describe('parse', function() {
     it('returns a Maybe', function() {
       eq(S.parseInt(10, '42'), S.Just(42));
       eq(S.parseInt(16, '2A'), S.Just(42));
+      eq(S.parseInt(10, 'NaN'), S.Nothing());
       eq(S.parseInt(10, 'xxx'), S.Nothing());
     });
 


### PR DESCRIPTION
Closes #18

I used `ghci` and [§ 9.8.1][1] as references.


[1]: http://www.ecma-international.org/ecma-262/5.1/#sec-9.8.1
