### PR TITLE
circle: run tests on Node v0.12.x in addition to Node v0.10.x

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,12 @@ dependencies:
 
 machine:
   node:
-    version: 0.10.26
+    version: 0.10.34
 
 test:
   override:
-    - make test lint
+    - make lint
+    - make test
+    - nvm install 0.12.7
+    - nvm alias default 0.12.7
+    - make test


### PR DESCRIPTION
I'm pleased to have learnt how to do this (from one of the members of the CircleCI support team).
