### PR TITLE
combinator: add S.I

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,6 +289,17 @@
 
   //. ### Combinator
 
+  //# I :: a -> a
+  //.
+  //. The I combinator. Returns its argument. Equivalent to Haskell's `id`
+  //. function.
+  //.
+  //. ```javascript
+  //. > S.I('foo')
+  //. "foo"
+  //. ```
+  S.I = def('I', [a], function(x) { return x; });
+
   //# K :: a -> b -> a
   //.
   //. The K combinator. Takes two values and returns the first. Equivalent to

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,19 @@ describe('classify', function() {
 
 describe('combinator', function() {
 
+  describe('I', function() {
+
+    it('is a unary function', function() {
+      eq(typeof S.I, 'function');
+      eq(S.I.length, 1);
+    });
+
+    it('returns its argument', function() {
+      eq(S.I([1, 2, 3]), [1, 2, 3]);
+    });
+
+  });
+
   describe('K', function() {
 
     it('is a binary function', function() {


### PR DESCRIPTION
Ramda provides [`R.identity`][1], of course, but `S.I` is much shorter:

```javascript
S.encaseEither(R.identity, JSON.parse)
```

```javascript
S.encaseEither(S.I, JSON.parse)
```

Since we already provide `S.K`, it seems more fitting to name this function `I` rather than `id`.


[1]: http://ramdajs.com/docs/#identity
