### PR TITLE
composition: add S.compose, S.pipe, and S.meld

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -205,6 +205,107 @@ describe('combinator', function() {
 
 });
 
+describe('composition', function() {
+
+  describe('compose', function() {
+
+    it('is a ternary function', function() {
+      eq(typeof S.compose, 'function');
+      eq(S.compose.length, 3);
+    });
+
+    it('composes two functions assumed to be unary', function() {
+      eq(S.compose(R.map(Math.sqrt), JSON.parse, '[1, 4, 9]'), [1, 2, 3]);
+    });
+
+    it('is curried', function() {
+      eq(S.compose(R.map(Math.sqrt)).length, 2);
+      eq(S.compose(R.map(Math.sqrt))(JSON.parse).length, 1);
+      eq(S.compose(R.map(Math.sqrt))(JSON.parse)('[1, 4, 9]'), [1, 2, 3]);
+    });
+
+  });
+
+  describe('pipe', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.pipe, 'function');
+      eq(S.pipe.length, 2);
+    });
+
+    it('composes a list of functions assumed to be unary', function() {
+      eq(S.pipe([], '99'), '99');
+      eq(S.pipe([parseInt], '99'), 99);
+      eq(S.pipe([parseInt, R.inc], '99'), 100);
+      eq(S.pipe([parseInt, R.inc, Math.sqrt], '99'), 10);
+      eq(S.pipe([parseInt, R.inc, Math.sqrt, R.dec], '99'), 9);
+    });
+
+    it('is curried', function() {
+      eq(S.pipe([parseInt, R.inc, Math.sqrt, R.dec]).length, 1);
+      eq(S.pipe([parseInt, R.inc, Math.sqrt, R.dec])('99'), 9);
+    });
+
+  });
+
+  describe('meld', function() {
+
+    it('is a unary function', function() {
+      eq(typeof S.meld, 'function');
+      eq(S.meld.length, 1);
+    });
+
+    it('composes a list of unary functions', function() {
+      eq(S.meld([]).length, 1);
+      eq(S.meld([])(99), 99);
+      eq(S.meld([R.inc]).length, 1);
+      eq(S.meld([R.inc])(99), 100);
+      eq(S.meld([R.inc, Math.sqrt]).length, 1);
+      eq(S.meld([R.inc, Math.sqrt])(99), 10);
+      eq(S.meld([R.inc, Math.sqrt, R.dec]).length, 1);
+      eq(S.meld([R.inc, Math.sqrt, R.dec])(99), 9);
+    });
+
+    it('melds a list of non-nullary functions of various arities', function() {
+      var f = function(x) { return -x; };
+      var g = function(x, y) { return Math.pow(x, y); };
+      var h = function(x, y, z) { return x + y + z; };
+
+      eq(S.meld([f, f, f]).length, 1);
+      eq(S.meld([f, f, g]).length, 2);
+      eq(S.meld([f, g, f]).length, 2);
+      eq(S.meld([g, f, f]).length, 2);
+      eq(S.meld([f, g, g]).length, 3);
+      eq(S.meld([g, f, g]).length, 3);
+      eq(S.meld([g, g, f]).length, 3);
+      eq(S.meld([g, g, g]).length, 4);
+
+      eq(S.meld([f, g, h]).length, 4);
+      eq(S.meld([f, h, g]).length, 4);
+      eq(S.meld([g, f, h]).length, 4);
+      eq(S.meld([g, h, f]).length, 4);
+      eq(S.meld([h, f, g]).length, 4);
+      eq(S.meld([h, g, f]).length, 4);
+
+      eq(S.meld([f, g, h])(3, 4, 5, 6), h(g(f(3), 4), 5, 6));
+      eq(S.meld([f, h, g])(3, 4, 5, 6), g(h(f(3), 4, 5), 6));
+      eq(S.meld([g, f, h])(3, 4, 5, 6), h(f(g(3, 4)), 5, 6));
+      eq(S.meld([g, h, f])(3, 4, 5, 6), f(h(g(3, 4), 5, 6)));
+      eq(S.meld([h, f, g])(3, 4, 5, 6), g(f(h(3, 4, 5)), 6));
+      eq(S.meld([h, g, f])(3, 4, 5, 6), f(g(h(3, 4, 5), 6)));
+
+      eq(S.meld([f, g, h])(3)(4)(5)(6), h(g(f(3), 4), 5, 6));
+      eq(S.meld([f, h, g])(3)(4)(5)(6), g(h(f(3), 4, 5), 6));
+      eq(S.meld([g, f, h])(3)(4)(5)(6), h(f(g(3, 4)), 5, 6));
+      eq(S.meld([g, h, f])(3)(4)(5)(6), f(h(g(3, 4), 5, 6)));
+      eq(S.meld([h, f, g])(3)(4)(5)(6), g(f(h(3, 4, 5)), 6));
+      eq(S.meld([h, g, f])(3)(4)(5)(6), f(g(h(3, 4, 5), 6)));
+    });
+
+  });
+
+});
+
 describe('maybe', function() {
 
   describe('Maybe', function() {


### PR DESCRIPTION
I proposed these functions in https://github.com/ramda/ramda/issues/1318#issuecomment-132005376. It's unlikely that Ramda will provide these exact functions but I happen to contribute to another functional programming library as well. ;)

The implementation of `compose` is wonderfully straightforward.

The implementation of `pipe` is elegant: a right fold over the list of functions, with `compose` as the reducing function and `identity` as the identity element.

I'm pleased with `meld` as the name of the third function. Is it appealing to others as well?

I'm interested to know whether this patch gets the @joneshf seal of approval; `compose` and `pipe` are intended to be easier to reason about than their Ramda counterparts.

I'd also like to hear from @CrossEye, @paldepind, and other Ramda contributors as some of these ideas should filter back into Ramda. We could, for example, revert `R.compose` and `R.pipe` to the pre-v0.17.0 behaviour and add `R.meld` (which would be a variadic to match `R.pipe`).
