### PR TITLE
regexp: add S.test

### DIFF
--- a/index.js
+++ b/index.js
@@ -2015,6 +2015,22 @@
     return new RegExp(source, flags);
   });
 
+  //# test :: RegExp -> String -> Boolean
+  //.
+  //. Takes a pattern and a string, and returns `true` if the pattern
+  //. matches the string; `false` otherwise.
+  //.
+  //. ```javascript
+  //. > S.test(/^a/, 'abacus')
+  //. true
+  //.
+  //. > S.test(/^a/, 'banana')
+  //. false
+  //. ```
+  S.test = def('test', [RegExp, String], function(pattern, s) {
+    return pattern.test(s);
+  });
+
   //# match :: RegExp -> String -> Maybe [Maybe String]
   //.
   //. Takes a pattern and a string, and returns Just a list of matches

--- a/test/index.js
+++ b/test/index.js
@@ -2938,6 +2938,40 @@ describe('regexp', function() {
 
   });
 
+  describe('test', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.test, 'function');
+      eq(S.test.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.test('^a'); },
+                    errorEq(TypeError,
+                            '‘test’ requires a value of type RegExp ' +
+                            'as its first argument; received "^a"'));
+
+      assert.throws(function() { S.test(/^a/, [1, 2, 3]); },
+                    errorEq(TypeError,
+                            '‘test’ requires a value of type String ' +
+                            'as its second argument; received [1, 2, 3]'));
+    });
+
+    it('returns true if pattern matches string', function() {
+      eq(S.test(/^a/, 'abacus'), true);
+    });
+
+    it('returns false if pattern does not match string', function() {
+      eq(S.test(/^a/, 'banana'), false);
+    });
+
+    it('is curried', function() {
+      eq(S.test(/^a/).length, 1);
+      eq(S.test(/^a/)('abacus'), true);
+    });
+
+  });
+
   describe('match', function() {
 
     it('is a binary function', function() {


### PR DESCRIPTION
Like [`R.test`][1], but with the type checking we know and love. See ramda/ramda#1413 for a compelling example of the problems that arise due to Ramda's lack of type checking.

/cc @albrow


[1]: http://ramdajs.com/docs/#test
