### PR TITLE
Add S.both function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1497,6 +1497,27 @@
     return xBool !== yBool ? or(x, y) : xEmpty;
   });
 
+  //# both :: (a -> Boolean) -> (a -> Boolean) -> a -> Boolean
+  //.
+  //. Takes two unary functions that return a boolean and applies them
+  //. both to the supplied value, returning true iff both functions
+  //. evaluate to true.
+  //.
+  //. ```javascript
+  //.
+  //. > S.both(S.test(/^a/), S.test(/.*f$/), 'abcdef')
+  //. true
+  //.
+  //. > S.both(S.test(/^a/), S.test(/.*e$/), 'abcdef')
+  //. false
+  //.
+  //. > S.both(S.test(/^b/), S.test(/.*e$/), 'abcdef')
+  //. false
+  //. ```
+  S.both = def('both', [Function, Function, a], function(f, g, x) {
+    return f(x) && g(x);
+  });
+
   //. ### List
 
   //# slice :: Integer -> Integer -> [a] -> Maybe [a]

--- a/index.js
+++ b/index.js
@@ -1500,7 +1500,7 @@
   //# both :: (a -> Boolean) -> (a -> Boolean) -> a -> Boolean
   //.
   //. Takes two unary predicates and a value of any type, and returns
-  //. true if the value satisfies both predicates; false otherwise.
+  //. `true` if the value satisfies both predicates; `false` otherwise.
   //.
   //. ```javascript
   //. > S.both(S.test(/a/), S.test(/b/), 'banana')

--- a/index.js
+++ b/index.js
@@ -1504,7 +1504,6 @@
   //. evaluate to true.
   //.
   //. ```javascript
-  //.
   //. > S.both(S.test(/^a/), S.test(/.*f$/), 'abcdef')
   //. true
   //.

--- a/index.js
+++ b/index.js
@@ -1499,18 +1499,17 @@
 
   //# both :: (a -> Boolean) -> (a -> Boolean) -> a -> Boolean
   //.
-  //. Takes two unary functions that return a boolean and applies them
-  //. both to the supplied value, returning true iff both functions
-  //. evaluate to true.
+  //. Takes two unary predicates and a value of any type, and returns
+  //. true if the value satisfies both predicates; false otherwise.
   //.
   //. ```javascript
-  //. > S.both(S.test(/^a/), S.test(/.*f$/), 'abcdef')
+  //. > S.both(S.test(/a/), S.test(/b/), 'banana')
   //. true
   //.
-  //. > S.both(S.test(/^a/), S.test(/.*e$/), 'abcdef')
+  //. > S.both(S.test(/a/), S.test(/b/), 'insouciant')
   //. false
   //.
-  //. > S.both(S.test(/^b/), S.test(/.*e$/), 'abcdef')
+  //. > S.both(S.test(/a/), S.test(/b/), 'serendipity')
   //. false
   //. ```
   S.both = def('both', [Function, Function, a], function(f, g, x) {

--- a/test/index.js
+++ b/test/index.js
@@ -1914,6 +1914,53 @@ describe('control', function() {
 
   });
 
+  describe('both', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.both, 'function');
+      eq(S.both.length, 3);
+    });
+
+    it('returns true when both predicates are satisfied', function() {
+      eq(S.both(S.test(/^a/), S.test(/.*f$/), 'abcdef'), true);
+    });
+
+    it('returns false when one predicate is satisfied', function() {
+      eq(S.both(S.test(/^a/), S.test(/.*f$/), 'abcde'), false);
+      eq(S.both(S.test(/^b/), S.test(/.*f$/), 'abcdef'), false);
+    });
+
+    it('returns false when no predicates are satisfied', function() {
+      eq(S.both(S.test(/^b/), S.test(/.*e$/), 'abcdef'), false);
+    });
+
+    it('short circuits if the first predicate is not satisfied', function() {
+      var evaluated = false;
+      var evaluate = function() { evaluated = true; };
+      eq(S.both(S.test(/^b/), evaluate, 'abcdef'), false);
+      eq(evaluated, false);
+    });
+
+    it('throws if not supplied a function', function() {
+      assert.throws(function() { S.both('string', S.test(/^a/), 'abcdef'); },
+          errorEq(TypeError,
+              '‘both’ requires a value of type Function as its ' +
+              'first argument; received "string"'));
+
+      assert.throws(function() { S.both(S.test(/.*f$/), 'string', 'abcdef'); },
+          errorEq(TypeError,
+              '‘both’ requires a value of type Function as its ' +
+              'second argument; received "string"'));
+    });
+
+    it('is curried', function() {
+      eq(S.both(S.test(/^a/), S.test(/.*f$/)).length, 1);
+      eq(S.both(S.test(/^a/)).length, 2);
+      eq(S.both(S.test(/^a/))(S.test(/.*f$/))('abcdef'), true);
+    });
+
+  });
+
 });
 
 describe('list', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1916,7 +1916,7 @@ describe('control', function() {
 
   describe('both', function() {
 
-    it('is a binary function', function() {
+    it('is a ternary function', function() {
       eq(typeof S.both, 'function');
       eq(S.both.length, 3);
     });

--- a/test/index.js
+++ b/test/index.js
@@ -1921,42 +1921,42 @@ describe('control', function() {
       eq(S.both.length, 3);
     });
 
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.both('string'); },
+          errorEq(TypeError,
+              '‘both’ requires a value of type Function as its ' +
+              'first argument; received "string"'));
+
+      assert.throws(function() { S.both(S.test(/^a/), 'string'); },
+          errorEq(TypeError,
+              '‘both’ requires a value of type Function as its ' +
+              'second argument; received "string"'));
+    });
+
     it('returns true when both predicates are satisfied', function() {
-      eq(S.both(S.test(/^a/), S.test(/.*f$/), 'abcdef'), true);
+      eq(S.both(S.test(/a/), S.test(/b/), 'banana'), true);
     });
 
     it('returns false when one predicate is satisfied', function() {
-      eq(S.both(S.test(/^a/), S.test(/.*f$/), 'abcde'), false);
-      eq(S.both(S.test(/^b/), S.test(/.*f$/), 'abcdef'), false);
+      eq(S.both(S.test(/a/), S.test(/b/), 'insouciant'), false);
+      eq(S.both(S.test(/b/), S.test(/a/), 'insouciant'), false);
     });
 
     it('returns false when no predicates are satisfied', function() {
-      eq(S.both(S.test(/^b/), S.test(/.*e$/), 'abcdef'), false);
+      eq(S.both(S.test(/a/), S.test(/b/), 'serendipity'), false);
     });
 
-    it('short circuits if the first predicate is not satisfied', function() {
+    it('short-circuits if the first predicate is not satisfied', function() {
       var evaluated = false;
       var evaluate = function() { evaluated = true; };
       eq(S.both(S.test(/^b/), evaluate, 'abcdef'), false);
       eq(evaluated, false);
     });
 
-    it('throws if not supplied a function', function() {
-      assert.throws(function() { S.both('string', S.test(/^a/), 'abcdef'); },
-          errorEq(TypeError,
-              '‘both’ requires a value of type Function as its ' +
-              'first argument; received "string"'));
-
-      assert.throws(function() { S.both(S.test(/.*f$/), 'string', 'abcdef'); },
-          errorEq(TypeError,
-              '‘both’ requires a value of type Function as its ' +
-              'second argument; received "string"'));
-    });
-
     it('is curried', function() {
-      eq(S.both(S.test(/^a/), S.test(/.*f$/)).length, 1);
-      eq(S.both(S.test(/^a/)).length, 2);
-      eq(S.both(S.test(/^a/))(S.test(/.*f$/))('abcdef'), true);
+      eq(S.both(S.test(/a/)).length, 2);
+      eq(S.both(S.test(/a/), S.test(/b/)).length, 1);
+      eq(S.both(S.test(/a/))(S.test(/b/))('banana'), true);
     });
 
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1923,14 +1923,14 @@ describe('control', function() {
 
     it('type checks its arguments', function() {
       assert.throws(function() { S.both('string'); },
-          errorEq(TypeError,
-              '‘both’ requires a value of type Function as its ' +
-              'first argument; received "string"'));
+             errorEq(TypeError,
+                     '‘both’ requires a value of type Function as its ' +
+                     'first argument; received "string"'));
 
       assert.throws(function() { S.both(S.test(/^a/), 'string'); },
-          errorEq(TypeError,
-              '‘both’ requires a value of type Function as its ' +
-              'second argument; received "string"'));
+             errorEq(TypeError,
+                     '‘both’ requires a value of type Function as its ' +
+                     'second argument; received "string"'));
     });
 
     it('returns true when both predicates are satisfied', function() {


### PR DESCRIPTION
I've chosen to only implement the `both` part of #102 for the moment just to get a feel for what's expected. The examples I've given in the docs are pretty contrived because there's really only `S.test` that returns a boolean. I could have used something like `R.has` but I wasn't sure what the policy of including Ramda functions in the docs was or even defining a custom function at the head of the `S.both` docs. I'll squash everything down to one commit at the end of code review.