### PR TITLE
Add complement and "either" function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1513,6 +1513,26 @@
     return !f(x);
   });
 
+  //# oneOf :: (a -> Boolean) -> (a -> Boolean) -> a -> Boolean
+  //.
+  //. Takes two unary predicates and a value of any type, and returns
+  //. `true` if the value satisfies one of the predicates; `false`
+  //. otherwise.
+  //.
+  //. ```javascript
+  //. > S.oneOf(S.test(/a/), S.test(/b/), 'insouciant')
+  //. true
+  //.
+  //. > S.oneOf(S.test(/a/), S.test(/b/), 'banana')
+  //. true
+  //.
+  //. > S.oneOf(S.test(/a/), S.test(/b/), 'serendipity')
+  //. false
+  //. ```
+  S.oneOf = def('oneOf', [Function, Function, a], function(f, g, x) {
+    return f(x) || g(x);
+  });
+
   //. ### List
 
   //# slice :: Integer -> Integer -> [a] -> Maybe [a]

--- a/index.js
+++ b/index.js
@@ -1497,6 +1497,22 @@
     return xBool !== yBool ? or(x, y) : xEmpty;
   });
 
+  //# complement :: (a -> Boolean) -> a -> Boolean
+  //.
+  //. Takes a unary predicate and a value of any type and inverts the
+  //. return value of the predicate when applied to the supplied value.
+  //.
+  //. ```javascript
+  //. > S.complement(S.test(/a/), 'quiescent')
+  //. true
+  //.
+  //. > S.complement(S.test(/a/), 'fissiparous')
+  //. false
+  //. ```
+  S.complement = def('complement', [Function, a], function(f, x) {
+    return !f(x);
+  });
+
   //. ### List
 
   //# slice :: Integer -> Integer -> [a] -> Maybe [a]

--- a/test/index.js
+++ b/test/index.js
@@ -1914,6 +1914,32 @@ describe('control', function() {
 
   });
 
+  describe('complement', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.complement, 'function');
+      eq(S.complement.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.complement('string'); },
+             errorEq(TypeError,
+                     '‘complement’ requires a value of type Function as its ' +
+                     'first argument; received "string"'));
+    });
+
+    it('inverts the return value of the supplied predicate', function() {
+      eq(S.complement(S.test(/a/), 'quiescent'), true);
+      eq(S.complement(S.test(/a/), 'fissiparous'), false);
+    });
+
+    it('is curried', function() {
+      eq(S.complement(S.test(/a/)).length, 1);
+      eq(S.complement(S.test(/a/))('quiescent'), true);
+    });
+
+  });
+
 });
 
 describe('list', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -1940,6 +1940,53 @@ describe('control', function() {
 
   });
 
+  describe('oneOf', function() {
+
+    it('is a ternary function', function() {
+      eq(typeof S.oneOf, 'function');
+      eq(S.oneOf.length, 3);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.oneOf('string'); },
+        errorEq(TypeError,
+          '‘oneOf’ requires a value of type Function as its ' +
+          'first argument; received "string"'));
+
+      assert.throws(function() { S.oneOf(S.test(/^a/), 'string'); },
+        errorEq(TypeError,
+          '‘oneOf’ requires a value of type Function as its ' +
+          'second argument; received "string"'));
+    });
+
+    it('returns true when one predicate is satisfied', function() {
+      eq(S.oneOf(S.test(/a/), S.test(/b/), 'insouciant'), true);
+      eq(S.oneOf(S.test(/b/), S.test(/a/), 'insouciant'), true);
+    });
+
+    it('returns true when both predicates are satisfied', function() {
+      eq(S.oneOf(S.test(/a/), S.test(/b/), 'banana'), true);
+    });
+
+    it('returns false when no predicates are satisfied', function() {
+      eq(S.oneOf(S.test(/a/), S.test(/b/), 'serendipity'), false);
+    });
+
+    it('short-circuits if the first predicate is satisfied', function() {
+      var evaluated = false;
+      var evaluate = function() { evaluated = true; };
+      eq(S.oneOf(S.test(/^a/), evaluate, 'abcdef'), true);
+      eq(evaluated, false);
+    });
+
+    it('is curried', function() {
+      eq(S.oneOf(S.test(/a/)).length, 2);
+      eq(S.oneOf(S.test(/a/), S.test(/b/)).length, 1);
+      eq(S.oneOf(S.test(/a/))(S.test(/z/))('banana'), true);
+    });
+
+  });
+
 });
 
 describe('list', function() {


### PR DESCRIPTION
Obviously merging this depends on the outcome of #102. I've renamed `either` to `oneOf` not because I think it's a good name but because I had to call it _something_. I can update the PR when we've made a decision.