### PR TITLE
regexp: add S.regexEscape

### DIFF
--- a/index.js
+++ b/index.js
@@ -2035,6 +2035,23 @@
     return new RegExp(source, flags);
   });
 
+  //# regexEscape :: String -> String
+  //.
+  //. Takes a string which may contain regular expression metacharacters,
+  //. and returns a string with those metacharacters escaped.
+  //.
+  //. Properties:
+  //.
+  //.   - `forall s :: String. S.test(S.regex('', S.regexEscape(s)), s) = true`
+  //.
+  //. ```javascript
+  //. > S.regexEscape('-=*{XYZ}*=-')
+  //. '\\-=\\*\\{XYZ\\}\\*=\\-'
+  //. ```
+  S.regexEscape = def('regexEscape', [String], function(s) {
+    return s.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  });
+
   //# test :: RegExp -> String -> Boolean
   //.
   //. Takes a pattern and a string, and returns `true` if the pattern

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "istanbul": "0.3.x",
     "jscs": "1.10.x",
     "jshint": "2.5.x",
+    "jsverify": "0.7.x",
     "mocha": "2.x.x",
     "transcribe": "0.3.x",
     "xyz": "0.5.x"

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@
 var assert = require('assert');
 var vm = require('vm');
 
+var jsc = require('jsverify');
 var R = require('ramda');
 
 var S = require('..');
@@ -2977,6 +2978,38 @@ describe('regexp', function() {
     it('is curried', function() {
       eq(S.regex('').length, 1);
       eq(S.regex('')('\\d'), /\d/);
+    });
+
+  });
+
+  describe('regexEscape', function() {
+
+    it('is a unary function', function() {
+      eq(typeof S.regexEscape, 'function');
+      eq(S.regexEscape.length, 1);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.regexEscape(/(?:)/); },
+                    errorEq(TypeError,
+                            '‘regexEscape’ requires a value of type String ' +
+                            'as its first argument; received /(?:)/'));
+    });
+
+    it('escapes regular expression metacharacters', function() {
+      eq(S.regexEscape('-=*{XYZ}*=-'), '\\-=\\*\\{XYZ\\}\\*=\\-');
+    });
+
+    it('property: test(regex("", regexEscape(s)), s)', function() {
+      jsc.assert(jsc.forall(jsc.string, function(s) {
+        return S.test(S.regex('', S.regexEscape(s)), s);
+      }), {tests: 1000});
+    });
+
+    it('property: test(regex("", "^" + regexEscape(s) + "$"), s)', function() {
+      jsc.assert(jsc.forall(jsc.string, function(s) {
+        return S.test(S.regex('', '^' + S.regexEscape(s) + '$'), s);
+      }), {tests: 1000});
     });
 
   });


### PR DESCRIPTION
This will obviate the need for dependencies such as [escape-regexp][1] when using Sanctuary.

I'm open to name suggestions. `escapeRegexMetachars` is more descriptive, but feels too long.

I copied the regular expression from [XRegExp][2].

This is the first time I've used [JSVerify][3]. I'm impressed. We should write more tests this way!


[1]: https://www.npmjs.com/package/escape-regexp
[2]: https://github.com/slevithan/xregexp/blob/v3.0.0/xregexp-all.js#L792-L806
[3]: https://github.com/jsverify/jsverify
