### PR TITLE
Add allPass and anyPass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1624,6 +1624,48 @@
     return pred(x) ? f(x) : g(x);
   });
 
+  //# allPass :: [a -> Boolean] -> a -> Boolean
+  //.
+  //. Takes an array of unary predicates and a value of any type
+  //. and returns `true` if all the predicates pass; `false` otherwise.
+  //. None of the subsequent predicates will be evaluated after the
+  //. first failed predicate.
+  //.
+  //. ```javascript
+  //. > S.allPass([S.test(/q/), S.test(/u/), S.test(/i/)], 'quiessence')
+  //. true
+  //.
+  //. > S.allPass([S.test(/q/), S.test(/u/), S.test(/i/)], 'fissiparous')
+  //. false
+  //. ```
+  S.allPass = def('allPass', [Array, a], function(preds, x) {
+    for (var idx = 0; idx < preds.length; idx += 1) {
+      if (!preds[idx](x)) return false;
+    }
+    return true;
+  });
+
+  //# anyPass :: [a -> Boolean] -> a -> Boolean
+  //.
+  //. Takes an array of unary predicates and a value of any type
+  //. and returns `true` if any of the predicates pass; `false` otherwise.
+  //. None of the subsequent predicates will be evaluated after the
+  //. first passed predicate.
+  //.
+  //. ```javascript
+  //. > S.anyPass([S.test(/q/), S.test(/u/), S.test(/i/)], 'incandescent')
+  //. true
+  //.
+  //. > S.anyPass([S.test(/q/), S.test(/u/), S.test(/i/)], 'empathy')
+  //. false
+  //. ```
+  S.anyPass = def('anyPass', [Array, a], function(preds, x) {
+    for (var idx = 0; idx < preds.length; idx += 1) {
+      if (preds[idx](x)) return true;
+    }
+    return false;
+  });
+
   //. ### List
 
   //# slice :: Integer -> Integer -> [a] -> Maybe [a]

--- a/test/index.js
+++ b/test/index.js
@@ -2175,6 +2175,164 @@ describe('control', function() {
 
   });
 
+  describe('allPass', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.allPass, 'function');
+      eq(S.allPass.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.allPass('wrong'); },
+                    errorEq(TypeError,
+                            '‘allPass’ requires a value of type Array ' +
+                            'as its first argument; received "wrong"'));
+    });
+
+    it('returns true when given an empty array of predicates', function() {
+      eq(S.allPass([], 'quiessence'), true);
+    });
+
+    it('returns true when all predicates pass', function() {
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'quiessence'),
+         true);
+    });
+
+    it('returns false when some predicates fail', function() {
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'quintessential'),
+         false);
+
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'incandescent'),
+         false);
+
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'fissiparous'),
+         false);
+    });
+
+    it('returns false when all predicates fail', function() {
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'empathy'),
+         false);
+    });
+
+    it('short-circuits when one predicate fails', function() {
+      var evaluated = false;
+      var evaluate = function() { evaluated = true; };
+
+      eq(S.allPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    evaluate],
+                   'incandescent'),
+         false);
+      eq(evaluated, false);
+    });
+
+    it('is curried', function() {
+      eq(S.allPass([S.test(/q/)]).length, 1);
+      eq(S.allPass([S.test(/q/)])('quiessence'), true);
+    });
+
+  });
+
+  describe('anyPass', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.anyPass, 'function');
+      eq(S.anyPass.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      assert.throws(function() { S.anyPass('wrong'); },
+                    errorEq(TypeError,
+                            '‘anyPass’ requires a value of type Array ' +
+                            'as its first argument; received "wrong"'));
+    });
+
+    it('returns false when given an empty array of predicates', function() {
+      eq(S.anyPass([], 'quiessence'), false);
+    });
+
+    it('returns true when all predicates pass', function() {
+      eq(S.anyPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'quiessence'),
+         true);
+    });
+
+    it('returns true when some predicates pass', function() {
+      eq(S.anyPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'quintessential'),
+         true);
+
+      eq(S.anyPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'incandescent'),
+         true);
+
+      eq(S.anyPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'fissiparous'),
+         true);
+    });
+
+    it('returns false when all predicates fail', function() {
+      eq(S.anyPass([S.test(/q/),
+                    S.test(/u/),
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'empathy'),
+         false);
+    });
+
+    it('it short-circuits when one predicate passes', function() {
+      var evaluated = false;
+      var evaluate = function() { evaluated = true; };
+
+      eq(S.anyPass([S.test(/q/),
+                    evaluate,
+                    S.test(/i/),
+                    S.test(/c/)],
+                   'quiessence'),
+         true);
+      eq(evaluated, false);
+    });
+
+    it('is curried', function() {
+      eq(S.anyPass([S.test(/q/)]).length, 1);
+      eq(S.anyPass([S.test(/q/)])('quiessence'), true);
+    });
+
+  });
+
 });
 
 describe('list', function() {


### PR DESCRIPTION
The most elegant implementation of these would be something like:

```js
S.allPass = (preds, a) => R.reduce((acc, f) => f(a) && acc, true, preds);
```
But then we'd lose short-circuiting.