### PR TITLE
Add traversable instance for Maybe

### DIFF
--- a/index.js
+++ b/index.js
@@ -540,8 +540,8 @@
   //. The Maybe type represents optional values: a value of type `Maybe a` is
   //. either a Just whose value is of type `a` or a Nothing (with no value).
   //.
-  //. The Maybe type satisfies the [Monoid][], [Monad][], [Foldable][], and
-  //. [Extend][] specifications.
+  //. The Maybe type satisfies the [Monoid][], [Monad][], [Traversable][],
+  //. and [Extend][] specifications.
   var Maybe = S.Maybe = function Maybe() {
     if (arguments[0] !== sentinel) {
       throw new Error('Cannot instantiate Maybe');
@@ -829,6 +829,29 @@
          [$Maybe(a), $.Function, b, b],
          function(maybe, f, x) {
            return maybe.isJust ? f(x, maybe.value) : x;
+         });
+
+  //# Maybe#sequence :: Applicative f => Maybe (f a) ~> (a -> f a) -> f (Maybe a)
+  //.
+  //. Evaluates an applicative action contained within the Maybe, resulting in:
+  //.
+  //.   - a pure applicative of a Nothing if `this` is a Nothing; otherwise
+  //.
+  //.   - an applicative of Just the value of the evaluated action.
+  //.
+  //. ```javascript
+  //. > S.Nothing().sequence(S.Either.of)
+  //. Right(Nothing())
+  //.
+  //. > S.Just(Right(42)).sequence(S.Either.of)
+  //. Right(Just(42))
+  //. ```
+  Maybe.prototype.sequence =
+  method('Maybe#sequence',
+         {a: [Apply], b: [Apply]},
+         [$Maybe(a), $.Function, b],
+         function(maybe, of) {
+           return maybe.isJust ? R.map(Just, maybe.value) : of(maybe);
          });
 
   //# Maybe#toBoolean :: Maybe a ~> Boolean
@@ -2491,10 +2514,10 @@
 
 //. [Apply]:        https://github.com/fantasyland/fantasy-land#apply
 //. [Extend]:       https://github.com/fantasyland/fantasy-land#extend
-//. [Foldable]:     https://github.com/fantasyland/fantasy-land#foldable
 //. [Functor]:      https://github.com/fantasyland/fantasy-land#functor
 //. [Monad]:        https://github.com/fantasyland/fantasy-land#monad
 //. [Monoid]:       https://github.com/fantasyland/fantasy-land#monoid
+//. [Traversable]:  https://github.com/fantasyland/fantasy-land#traversable
 //. [R.equals]:     http://ramdajs.com/docs/#equals
 //. [R.map]:        http://ramdajs.com/docs/#map
 //. [R.type]:       http://ramdajs.com/docs/#type

--- a/test/index.js
+++ b/test/index.js
@@ -67,6 +67,79 @@ var squareRoot = function(n) {
                : S.Right(Math.sqrt(n));
 };
 
+//  Identity :: a -> Identity a
+var Identity = function(x) {
+  return {
+    map: function(fn) {
+      return Identity(fn(x));
+    },
+    ap: function(y) {
+      return Identity(x(y));
+    },
+    equals: function(other) {
+      return R.equals(x, other.value);
+    },
+    value: x
+  };
+};
+Identity.of = Identity;
+
+//  Compose :: Apply f, Apply g
+//          => { of: b -> f b } -> { of: c -> g c }
+//          -> f (g a) -> Compose f g a
+var Compose = function(F, G) {
+  function _Compose(x) {
+    return {
+      map: function(f) {
+        return _Compose(R.map(R.map(f), x));
+      },
+      ap: function(y) {
+        return _Compose(R.ap(R.map(R.ap, x), y.value));
+      },
+      equals: function(other) {
+        return R.equals(x, other.value);
+      },
+      value: x
+    };
+  }
+  _Compose.of = function(x) {
+    return _Compose(F.of(G.of(x)));
+  };
+  return _Compose;
+};
+
+//  eitherToMaybe :: Either a b -> Maybe b
+var eitherToMaybe = S.either(S.K(S.Nothing()), S.Just);
+
+//  JustArb :: Arbitrary a -> Arbitrary (Maybe a)
+var JustArb = function(arb) {
+  return arb.smap(S.Just, function(m) { return m.value; }, R.toString);
+};
+
+//  MaybeArb :: Arbitrary a -> Arbitrary (Maybe a)
+var MaybeArb = function(arb) {
+  return jsc.oneof(JustArb(arb), jsc.constant(S.Nothing()));
+};
+
+//  LeftArb :: Arbitrary a -> Arbitrary (Either a b)
+var LeftArb = function(arb) {
+  return arb.smap(S.Left, function(e) { return e.value; }, R.toString);
+};
+
+//  RightArb :: Arbitrary a -> Arbitrary (Either b a)
+var RightArb = function(arb) {
+  return arb.smap(S.Right, function(e) { return e.value; }, R.toString);
+};
+
+//  EitherArb :: Arbitrary a -> Arbitrary b -> Arbitrary (Either a b)
+var EitherArb = function(lArb, rArb) {
+  return jsc.oneof(LeftArb(lArb), RightArb(rArb));
+};
+
+//  IdentityArb :: Arbitrary a -> Arbitrary (Identity a)
+var IdentityArb = function(arb) {
+  return arb.smap(Identity, function(i) { return i.value; });
+};
 
 describe('invariants', function() {
 
@@ -478,6 +551,37 @@ describe('maybe', function() {
                     errorEq(Error, 'Cannot instantiate Maybe'));
     });
 
+    describe('Traversable laws', function() {
+
+      it('satisfies naturality', function() {
+        jsc.assert(jsc.forall(MaybeArb(EitherArb(jsc.integer, jsc.string)), function(maybe) {
+          var lhs = eitherToMaybe(maybe.sequence(S.Either.of));
+          var rhs = maybe.map(eitherToMaybe).sequence(S.Maybe.of);
+          return lhs.equals(rhs);
+        }));
+      });
+
+      it('satisfies identity', function() {
+        jsc.assert(jsc.forall(MaybeArb(jsc.integer), function(maybe) {
+          var lhs = maybe.map(Identity).sequence(Identity.of);
+          var rhs = Identity.of(maybe);
+          return lhs.equals(rhs);
+        }));
+      });
+
+      it('satisfies composition', function() {
+        jsc.assert(jsc.forall(MaybeArb(IdentityArb(MaybeArb(jsc.integer))), function(u) {
+          var C = Compose(Identity, S.Maybe);
+          var lhs = u.map(C).sequence(C.of);
+          var rhs = C(u.sequence(Identity.of).map(function(x) {
+            return x.sequence(S.Maybe.of);
+          }));
+          return lhs.equals(rhs);
+        }));
+      });
+
+    });
+
   });
 
   describe('Nothing', function() {
@@ -591,6 +695,11 @@ describe('maybe', function() {
                     errorEq(TypeError,
                             '‘Maybe#reduce’ expected a value of type ' +
                             'Function as its first argument; received null'));
+    });
+
+    it('provides a "sequence" method', function() {
+      eq(S.Nothing().sequence.length, 1);
+      eq(S.Nothing().sequence(S.Either.of), S.Right(S.Nothing()));
     });
 
     it('provides a "toBoolean" method', function() {
@@ -822,6 +931,11 @@ describe('maybe', function() {
                     errorEq(TypeError,
                             '‘Maybe#reduce’ expected a value of type ' +
                             'Function as its first argument; received null'));
+    });
+
+    it('provides a "sequence" method', function() {
+      eq(S.Just(S.Right(42)).sequence.length, 1);
+      eq(S.Just(S.Right(42)).sequence(S.Either.of), S.Right(S.Just(42)));
     });
 
     it('provides a "toBoolean" method', function() {


### PR DESCRIPTION
Implements #118 

As per the included docs:

**Maybe#sequence :: Applicative f => Maybe (f a) ~> (b -> f b) -> f (Maybe a)**

Evaluates an applicative action contained within the Maybe, resulting in:
  - an applicative of `Just` the value of the evaluated action if `this`
    is a `Just`.
  - a pure applicative of `Nothing` if `this` is a `Nothing`.
```javascript
> S.Nothing().sequence(S.Either.of)
Right(Nothing())

> S.Just(Right(42)).sequence(S.Either.of)
Right(Just(42))
```