### PR TITLE
regexp: make S.test referentially transparent for "global" patterns

### DIFF
--- a/index.js
+++ b/index.js
@@ -2263,7 +2263,10 @@
   //. false
   //. ```
   S.test = def('test', [RegExp, String], function(pattern, s) {
-    return pattern.test(s);
+    var lastIndex = pattern.lastIndex;
+    var result = pattern.test(s);
+    pattern.lastIndex = lastIndex;
+    return result;
   });
 
   //# match :: RegExp -> String -> Maybe [Maybe String]

--- a/test/index.js
+++ b/test/index.js
@@ -3497,6 +3497,14 @@ describe('regexp', function() {
       eq(S.test(/^a/, 'banana'), false);
     });
 
+    it('is referentially transparent', function() {
+      var pattern = /x/g;
+      eq(pattern.lastIndex, 0);
+      eq(S.test(pattern, 'xyz'), true);
+      eq(pattern.lastIndex, 0);
+      eq(S.test(pattern, 'xyz'), true);
+    });
+
     it('is curried', function() {
       eq(S.test(/^a/).length, 1);
       eq(S.test(/^a/)('abacus'), true);


### PR DESCRIPTION
See purescript/purescript-strings#54

`R.test` has always behaved this way. I simply forgot about this internal state when preparing #109.
