### PR TITLE
ramda@0.19.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,8 @@
     "types"
   ],
   "dependencies": {
-    "ramda": "0.17.x"
+    "ramda": "0.19.x",
+    "sanctuary-def": "0.3.x"
   },
   "ignore": [
     "/.git/",

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ test:
     - make lint
     - make test
     - nvm install 0.12.7
-    - nvm alias default 0.12.7
-    - make test
-    - nvm use 4 && make test
-    - nvm use 5 && make test
+    - nvm use 0.12.7 && rm -r node_modules && make setup test
+    - nvm use 4 && rm -r node_modules && make setup test
+    - nvm use 5 && rm -r node_modules && make setup test

--- a/index.js
+++ b/index.js
@@ -2310,7 +2310,7 @@
                           R.all(R.pipe(R.toUpper,
                                        R.indexOf(_, charset),
                                        R.gte(_, 0))))),
-          R.map(R.partialRight(parseInt, radix)),
+          R.map(R.partialRight(parseInt, [radix])),
           R.filter(Integer.test)
         )(s);
       });

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/plaid/sanctuary.git"
   },
   "dependencies": {
-    "ramda": "0.17.x",
+    "ramda": "0.19.x",
     "sanctuary-def": "0.3.x"
   },
   "devDependencies": {


### PR DESCRIPTION
See the [0.18.0][1] and [0.19.0][2] upgrade guides.

I typically upgrade Ramda one minor version at a time, but I had trouble with one of the doctests when running 0.18.0, so I decided to skip that version. The changes are minimal, at any rate.


[1]: https://github.com/ramda/ramda/issues/1436
[2]: https://github.com/ramda/ramda/issues/1558
