### PR TITLE
sanctuary-def@0.4.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "ramda": "0.19.x",
-    "sanctuary-def": "0.3.x"
+    "sanctuary-def": "0.4.x"
   },
   "ignore": [
     "/.git/",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ramda": "0.19.x",
-    "sanctuary-def": "0.3.x"
+    "sanctuary-def": "0.4.x"
   },
   "devDependencies": {
     "doctest": "0.10.x",

--- a/test/index.js
+++ b/test/index.js
@@ -4482,3 +4482,17 @@ describe('string', function() {
   });
 
 });
+
+describe('unchecked', function() {
+
+  it('has the same properties as the top-level module', function() {
+    eq(R.sortBy(S.I, R.keys(S.unchecked)),
+       R.sortBy(S.I, R.without(['unchecked'], R.keys(S))));
+  });
+
+  it('provides functions which do not perform type checking', function() {
+    eq(S.unchecked.inc(42), S.inc(42));
+    eq(S.unchecked.inc('XXX'), 'XXX1');
+  });
+
+});


### PR DESCRIPTION
`sanctuary-def@0.4.0` has not yet been released, but this needn't stop us from preparing.

In plaid/sanctuary-def#28 we made type checking optional. The most straightforward change would be to replace `$.create(env)` with `$.create(true, env)`. Sanctuary's slowness, though, was the motivation for making type checking optional in sanctuary-def, so Sanctuary must also provide a way to opt out of type checking.

The solution employed in this pull request is to provide two versions of the Sanctuary module: one with type checking; one without.

Sanctuary, with type checking:

```javascript
const S = require('sanctuary');
```

Sanctuary, without type checking:

```javascript
const S = require('sanctuary').unchecked;
```
