### PR TITLE
refactor toMaybe to avoid applying Nothing to an argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1022,7 +1022,7 @@
   def('toMaybe',
       {},
       [$.Any, $Maybe(a)],
-      R.ifElse(R.isNil, Nothing, Just));
+      function(x) { return x == null ? Nothing() : Just(x); });
 
   //# maybe :: b -> (a -> b) -> Maybe a -> b
   //.


### PR DESCRIPTION
`R.ifElse(R.isNil, Nothing, Just)` is misleading since `Nothing` is a nullary constructor. It *happens* to work because `Nothing` doesn't complain about the unexpected argument, but I don't like to rely on this.
