### PR TITLE
Add npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/plaid/sanctuary.git"
   },
+  "scripts": {
+    "test": "make test lint"
+  },
   "dependencies": {
     "ramda": "0.19.x",
     "sanctuary-def": "0.4.x"


### PR DESCRIPTION
As mentioned in https://github.com/plaid/sanctuary-def/pull/19, I keep typing `npm test` when running my tests. This PR makes `Sanctuary`'s package.json consistent with `sanctuary-def`.