### PR TITLE
Add prop function

### DIFF
--- a/index.js
+++ b/index.js
@@ -353,6 +353,22 @@
                function() { return R.apply(f, R.prepend(this, arguments)); });
   };
 
+  //  prop :: Accessible a => String -> a -> b
+  var prop =
+  def('prop',
+      {a: [Accessible]},
+      [$.String, a, b],
+      function(key, obj) {
+        var boxed = Object(obj);
+        if (key in boxed) {
+          return boxed[key];
+        } else {
+          throw new TypeError('‘prop’ expected object to have a property ' +
+                              'named ‘' + key + '’; ' +
+                              R.toString(obj) + ' does not');
+        }
+      });
+
   //. ### Classify
 
   //# type :: a -> String
@@ -1024,7 +1040,7 @@
   method('Maybe#toBoolean',
          {},
          [$Maybe(a), $.Boolean],
-         R.prop('isJust'));
+         prop('isJust'));
 
   //# Maybe#toString :: Maybe a ~> String
   //.
@@ -1111,7 +1127,7 @@
   def('isNothing',
       {},
       [$Maybe(a), $.Boolean],
-      R.prop('isNothing'));
+      prop('isNothing'));
 
   //# isJust :: Maybe a -> Boolean
   //.
@@ -1128,7 +1144,7 @@
   def('isJust',
       {},
       [$Maybe(a), $.Boolean],
-      R.prop('isJust'));
+      prop('isJust'));
 
   //# fromMaybe :: a -> Maybe a -> a
   //.
@@ -1532,7 +1548,7 @@
   method('Either#toBoolean',
          {},
          [$Either(a, b), $.Boolean],
-         R.prop('isRight'));
+         prop('isRight'));
 
   //# Either#toString :: Either a b ~> String
   //.
@@ -1621,7 +1637,7 @@
   def('isLeft',
       {},
       [$Either(a, b), $.Boolean],
-      R.prop('isLeft'));
+      prop('isLeft'));
 
   //# isRight :: Either a b -> Boolean
   //.
@@ -1638,7 +1654,7 @@
   def('isRight',
       {},
       [$Either(a, b), $.Boolean],
-      R.prop('isRight'));
+      prop('isRight'));
 
   //# either :: (a -> c) -> (b -> c) -> Either a b -> c
   //.
@@ -1715,7 +1731,7 @@
   //. > S.encaseEither(S.I, JSON.parse, '[')
   //. Left(new SyntaxError('Unexpected end of input'))
   //.
-  //. > S.encaseEither(R.prop('message'), JSON.parse, '[')
+  //. > S.encaseEither(S.prop('message'), JSON.parse, '[')
   //. Left('Unexpected end of input')
   //. ```
   S.encaseEither =
@@ -2407,6 +2423,20 @@
 
   //. ### Object
 
+  //# prop :: Accessible a => String -> a -> b
+  //.
+  //. Takes a property name and an object with known properties and returns
+  //. the value of the specified property. If for some reason the object
+  //. lacks the specified property, a type error is thrown.
+  //.
+  //. For accessing properties of uncertain objects, use [`get`](#get) instead.
+  //.
+  //. ```javascript
+  //. > S.prop('a', {a: 1, b: 2})
+  //. 1
+  //. ```
+  S.prop = prop;
+
   //# get :: Accessible a => TypeRep b -> String -> a -> Maybe b
   //.
   //. Takes a [type representative](#type-representatives), a property
@@ -2417,7 +2447,7 @@
   //. The `Object` type representative may be used as a catch-all since most
   //. values have `Object.prototype` in their prototype chains.
   //.
-  //. See also [`gets`](#gets).
+  //. See also [`gets`](#gets) and [`prop`](#prop).
   //.
   //. ```javascript
   //. > S.get(Number, 'x', {x: 1, y: 2})

--- a/test/index.js
+++ b/test/index.js
@@ -2452,7 +2452,7 @@ describe('either', function() {
     });
 
     it('applies the first argument to the Error', function() {
-      eq(S.encaseEither(R.prop('message'), factorial, -1),
+      eq(S.encaseEither(S.prop('message'), factorial, -1),
          S.Left('Cannot determine factorial of negative number'));
     });
 
@@ -2512,7 +2512,7 @@ describe('either', function() {
     });
 
     it('applies the first argument to the Error', function() {
-      eq(S.encaseEither2(R.prop('message'), rem, 42, 0),
+      eq(S.encaseEither2(S.prop('message'), rem, 42, 0),
          S.Left('Cannot divide by zero'));
     });
 
@@ -2573,7 +2573,7 @@ describe('either', function() {
     });
 
     it('applies the first argument to the Error', function() {
-      eq(S.encaseEither3(R.prop('message'), area, 2, 2, 5),
+      eq(S.encaseEither3(S.prop('message'), area, 2, 2, 5),
          S.Left('Impossible triangle'));
     });
 
@@ -4104,6 +4104,76 @@ describe('list', function() {
 });
 
 describe('object', function() {
+
+  describe('prop', function() {
+
+    it('is a binary function', function() {
+      eq(typeof S.prop, 'function');
+      eq(S.prop.length, 2);
+    });
+
+    it('type checks its arguments', function() {
+      throws(function() { S.prop(1); },
+             errorEq(TypeError,
+                     'Invalid value\n' +
+                     '\n' +
+                     'prop :: Accessible a => String -> a -> b\n' +
+                     '                        ^^^^^^\n' +
+                     '                          1\n' +
+                     '\n' +
+                     '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+                     '\n' +
+                     'The value at position 1 is not a member of ‘String’.\n'));
+
+      throws(function() { S.prop('a', null); },
+             errorEq(TypeError,
+                     'Type-class constraint violation\n' +
+                     '\n' +
+                     'prop :: Accessible a => String -> a -> b\n' +
+                     '        ^^^^^^^^^^^^              ^\n' +
+                     '                                  1\n' +
+                     '\n' +
+                     '1)  null :: Null\n' +
+                     '\n' +
+                     '‘prop’ requires ‘a’ to satisfy the Accessible type-class constraint; the value at position 1 does not.\n'));
+
+      throws(function() { S.prop('a', true); },
+             errorEq(TypeError,
+                     '‘prop’ expected object to have a property named ‘a’; true does not'));
+
+      throws(function() { S.prop('a', 1); },
+             errorEq(TypeError,
+                     '‘prop’ expected object to have a property named ‘a’; 1 does not'));
+    });
+
+    it('throws when the property is not present', function() {
+      throws(function() { S.prop('map', 'abcd'); },
+             errorEq(TypeError,
+                     '‘prop’ expected object to have a property named ‘map’; "abcd" does not'));
+
+      throws(function() { S.prop('c', {a: 0, b: 1}); },
+             errorEq(TypeError,
+                     '‘prop’ expected object to have a property named ‘c’; {"a": 0, "b": 1} does not'));
+
+      throws(function() { S.prop('xxx', [1, 2, 3]); },
+             errorEq(TypeError,
+                     '‘prop’ expected object to have a property named ‘xxx’; [1, 2, 3] does not'));
+    });
+
+    it('it returns the value of the specified object property', function() {
+      eq(S.prop('a', {a: 0, b: 1}), 0);
+      eq(S.prop('0', [1, 2, 3]), 1);
+      eq(S.prop('length', 'abc'), 3);
+      eq(S.prop('x', Object.create({x: 1, y: 2})), 1);
+      eq(S.prop('global', /x/g), true);
+    });
+
+    it('is curried', function() {
+      eq(S.prop('a').length, 1);
+      eq(S.prop('a')({a: 0, b: 1}), 0);
+    });
+
+  });
 
   describe('get', function() {
 


### PR DESCRIPTION
As discussed in #159. I've a few reservations about this, firstly if I define `S.prop` as `var prop = S.prop = def(...` then I get lots of errors in the tests when I replace instances of `R.prop` in `index.js`:

>TypeError: prop is not a function
    at createSanctuary (/home/stefano/git/sanctuary/index.js:9:16296)
    at /home/stefano/git/sanctuary/index.js:9:45767
    at _ (/home/stefano/git/sanctuary/index.js:9:268)
    at Object.<anonymous> (/home/stefano/git/sanctuary/index.js:9:779)

Another thing is that `Accessible` is a very permissive type for this function, it allows you to pass numbers or booleans in even though they don't support property access so you end up getting error messages that leak implementation details to the user:

```js
S.prop('a', true)
// => TypeError: Cannot use 'in' operator to search for 'a' in true
```

Also, I think it's strange that a function that operates on `Records` should consider keys that are present in the prototype chain. What are people's thoughts?