### PR TITLE
Safer common.js module system detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@
   'use strict';
 
   /* istanbul ignore else */
-  if (typeof module !== 'undefined') {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
     module.exports = f(require('ramda'), require('sanctuary-def'));
   } else if (typeof define === 'function' && define.amd != null) {
     define(['ramda', 'sanctuary-def'], f);


### PR DESCRIPTION
Sanctuary is using this code to detect common.js module system:
```
   if (typeof module !== 'undefined') {
      module.exports = f(require('ramda'), require('sanctuary-def'));
   }
```

But this is definitely not enough. Because 'module' is a common variable name and could easily be in use not by the common.js module system. For example in my angular application it is used by 'angular-mocks.js' to inject angular module dependencies. So sanctuary causes an error in my environment.

My decision to check for 'module.exports' was inspired by:
   http://code.jquery.com/jquery-2.2.2.js
   https://raw.githubusercontent.com/lodash/lodash/4.6.1/dist/lodash.js
   https://github.com/jashkenas/underscore/blob/master/underscore.js