### PR TITLE
S.is() returned wrong result in IE 11

### DIFF
--- a/index.js
+++ b/index.js
@@ -386,7 +386,7 @@
         return x != null && (
           R.type(type.prototype['@@type']) === 'String' ?
             x['@@type'] === type.prototype['@@type'] :
-            R.type(x) === R.nth(1, R.match(/^function (\w*)/, String(type)))
+            R.type(x) === R.nth(1, R.match(/function (\w*)/, String(type)))
         );
       });
 


### PR DESCRIPTION
In the current sanctuary version this code returns wrong result in IE 11:
`   S.is(Array, []) // It would be false`

The problem is in how sanctuary determines the type. More precisely how it compares user's constructor (Array) and the value from R.type() in 386th line:
`   R.type(x) === R.nth(1, R.match(/^function (\w*)/, String(type)))`

The actual problem is that this code returns different results in different browsers:
```
   String(Array)
   // In chrome — "function Array() { [native code] }"
   // In IE 11  — "\nfunction Array() {\n    [native code]\n}\n"
```

ECMA 262 5.1 says that the result of String(Array) is not determined and the count of whitespaces depends on implementation:

> 15.3.4.2 Function.prototype.toString ( )
> An implementation-dependent representation of the function is returned. This representation has the syntax of a FunctionDeclaration. Note in particular that the use and placement of white space, line terminators, and semicolons within the representation String is implementation-dependent.

That is why it is very unsafe to obtain constructor's name in this way. In future we can use a new (ES2015) 'Array.name' property: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Function/name But for now I don't think there is a way to make this regular expression safe. We can accept the string "array" instead of an Array to elude this problem.