### PR TITLE
maybe: rename S.catMaybes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1201,16 +1201,19 @@
       [b, $.Function, $Maybe(a), b],
       function(x, f, maybe) { return fromMaybe(x, maybe.map(f)); });
 
-  //# catMaybes :: [Maybe a] -> [a]
+  //# justs :: [Maybe a] -> [a]
   //.
   //. Takes a list of Maybes and returns a list containing each Just's value.
+  //. Equivalent to Haskell's `catMaybes` function.
+  //.
+  //. See also [`lefts`](#lefts) and [`rights`](#rights).
   //.
   //. ```javascript
-  //. > S.catMaybes([S.Just('foo'), S.Nothing(), S.Just('baz')])
+  //. > S.justs([S.Just('foo'), S.Nothing(), S.Just('baz')])
   //. ['foo', 'baz']
   //. ```
-  var catMaybes = S.catMaybes =
-  def('catMaybes',
+  var justs = S.justs =
+  def('justs',
       {},
       [$.Array($Maybe(a)), $.Array(a)],
       R.chain(maybe([], R.of)));
@@ -1233,7 +1236,7 @@
   def('mapMaybe',
       {},
       [$.Function, $.Array(a), $.Array(b)],
-      meld([R.map, catMaybes]));
+      meld([R.map, justs]));
 
   //# encase :: (a -> b) -> a -> Maybe b
   //.

--- a/test/justs.js
+++ b/test/justs.js
@@ -8,21 +8,21 @@ var errorEq = require('./utils').errorEq;
 var S = require('..');
 
 
-describe('catMaybes', function() {
+describe('justs', function() {
 
   it('is a unary function', function() {
-    eq(typeof S.catMaybes, 'function');
-    eq(S.catMaybes.length, 1);
+    eq(typeof S.justs, 'function');
+    eq(S.justs.length, 1);
   });
 
   it('type checks its arguments', function() {
-    throws(function() { S.catMaybes({length: 0}); },
+    throws(function() { S.justs({length: 0}); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
-                   'catMaybes :: Array (Maybe a) -> Array a\n' +
-                   '             ^^^^^^^^^^^^^^^\n' +
-                   '                    1\n' +
+                   'justs :: Array (Maybe a) -> Array a\n' +
+                   '         ^^^^^^^^^^^^^^^\n' +
+                   '                1\n' +
                    '\n' +
                    '1)  {"length": 0} :: Object, StrMap Number, StrMap FiniteNumber, StrMap Integer, StrMap ValidNumber\n' +
                    '\n' +
@@ -30,11 +30,11 @@ describe('catMaybes', function() {
   });
 
   it('returns a list containing the value of each Just', function() {
-    eq(S.catMaybes([]), []);
-    eq(S.catMaybes([S.Nothing(), S.Nothing()]), []);
-    eq(S.catMaybes([S.Nothing(), S.Just('b')]), ['b']);
-    eq(S.catMaybes([S.Just('a'), S.Nothing()]), ['a']);
-    eq(S.catMaybes([S.Just('a'), S.Just('b')]), ['a', 'b']);
+    eq(S.justs([]), []);
+    eq(S.justs([S.Nothing(), S.Nothing()]), []);
+    eq(S.justs([S.Nothing(), S.Just('b')]), ['b']);
+    eq(S.justs([S.Just('a'), S.Nothing()]), ['a']);
+    eq(S.justs([S.Just('a'), S.Just('b')]), ['a', 'b']);
   });
 
 });


### PR DESCRIPTION
`justs` is consistent with [`lefts`][1] and [`rights`][2]. I consider it more important for Sanctuary to be internally consistent than it is to preserve Haskell's function names.


[1]: http://sanctuary.js.org/#lefts
[2]: http://sanctuary.js.org/#rights
