### PR TITLE
rename files to support file systems which are not case-sensitive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ NPM = npm
 TRANSCRIBE = node_modules/.bin/transcribe
 XYZ = node_modules/.bin/xyz --repo git@github.com:plaid/sanctuary.git --script scripts/prepublish
 
+TESTS = $(shell find test -name '*.js' | sort)
+
 
 .PHONY: all
 all: README.md
@@ -20,8 +22,8 @@ README.md: index.js
 
 .PHONY: lint
 lint:
-	$(JSHINT) -- index.js test/*.js
-	$(JSCS) -- index.js test/*.js
+	@$(JSHINT) -- index.js $(TESTS)
+	@$(JSCS) -- index.js $(TESTS)
 	@echo 'Checking for missing link definitions...'
 	grep -o '\[[^]]*\]\[[^]]*\]' index.js \
 	| sort -u \

--- a/test/Either/Either.js
+++ b/test/Either/Either.js
@@ -2,8 +2,8 @@
 
 var throws = require('assert').throws;
 
-var errorEq = require('./utils').errorEq;
-var S = require('..');
+var errorEq = require('../utils').errorEq;
+var S = require('../..');
 
 
 describe('Either', function() {

--- a/test/Either/EitherType.js
+++ b/test/Either/EitherType.js
@@ -2,8 +2,8 @@
 
 var $ = require('sanctuary-def');
 
-var eq = require('./utils').eq;
-var S = require('..');
+var eq = require('../utils').eq;
+var S = require('../..');
 
 
 describe('EitherType', function() {

--- a/test/Either/Left.js
+++ b/test/Either/Left.js
@@ -3,12 +3,12 @@
 var assert = require('assert');
 var throws = assert.throws;
 
-var eq = require('./utils').eq;
-var errorEq = require('./utils').errorEq;
-var parseHex = require('./utils').parseHex;
-var S = require('..');
-var square = require('./utils').square;
-var squareRoot = require('./utils').squareRoot;
+var eq = require('../utils').eq;
+var errorEq = require('../utils').errorEq;
+var parseHex = require('../utils').parseHex;
+var S = require('../..');
+var square = require('../utils').square;
+var squareRoot = require('../utils').squareRoot;
 
 
 describe('Left', function() {

--- a/test/Either/Right.js
+++ b/test/Either/Right.js
@@ -3,12 +3,12 @@
 var assert = require('assert');
 var throws = assert.throws;
 
-var eq = require('./utils').eq;
-var errorEq = require('./utils').errorEq;
-var parseHex = require('./utils').parseHex;
-var S = require('..');
-var square = require('./utils').square;
-var squareRoot = require('./utils').squareRoot;
+var eq = require('../utils').eq;
+var errorEq = require('../utils').errorEq;
+var parseHex = require('../utils').parseHex;
+var S = require('../..');
+var square = require('../utils').square;
+var squareRoot = require('../utils').squareRoot;
 
 
 describe('Right', function() {

--- a/test/Maybe/Maybe.js
+++ b/test/Maybe/Maybe.js
@@ -4,8 +4,8 @@ var jsc = require('jsverify');
 var R = require('ramda');
 var throws = require('assert').throws;
 
-var errorEq = require('./utils').errorEq;
-var S = require('..');
+var errorEq = require('../utils').errorEq;
+var S = require('../..');
 
 
 //  Identity :: a -> Identity a

--- a/test/Maybe/MaybeType.js
+++ b/test/Maybe/MaybeType.js
@@ -2,8 +2,8 @@
 
 var $ = require('sanctuary-def');
 
-var eq = require('./utils').eq;
-var S = require('..');
+var eq = require('../utils').eq;
+var S = require('../..');
 
 
 describe('MaybeType', function() {

--- a/test/Maybe/Nothing.js
+++ b/test/Maybe/Nothing.js
@@ -5,28 +5,28 @@ var throws = assert.throws;
 
 var R = require('ramda');
 
-var eq = require('./utils').eq;
-var errorEq = require('./utils').errorEq;
-var S = require('..');
-var square = require('./utils').square;
+var eq = require('../utils').eq;
+var errorEq = require('../utils').errorEq;
+var S = require('../..');
+var square = require('../utils').square;
 
 
-describe('Just', function() {
+describe('Nothing', function() {
 
   it('is a data constructor', function() {
-    eq(typeof S.Just, 'function');
-    eq(S.Just.length, 1);
-    eq(S.Just(42)['@@type'], 'sanctuary/Maybe');
-    eq(S.Just(42).isNothing, false);
-    eq(S.Just(42).isJust, true);
+    eq(typeof S.Nothing, 'function');
+    eq(S.Nothing.length, 0);
+    eq(S.Nothing()['@@type'], 'sanctuary/Maybe');
+    eq(S.Nothing().isNothing, true);
+    eq(S.Nothing().isJust, false);
   });
 
   it('provides an "ap" method', function() {
-    eq(S.Just(S.inc).ap.length, 1);
-    eq(S.Just(S.inc).ap(S.Nothing()), S.Nothing());
-    eq(S.Just(S.inc).ap(S.Just(42)), S.Just(43));
+    eq(S.Nothing().ap.length, 1);
+    eq(S.Nothing().ap(S.Nothing()), S.Nothing());
+    eq(S.Nothing().ap(S.Just(42)), S.Nothing());
 
-    throws(function() { S.Just(S.inc).ap([1, 2, 3]); },
+    throws(function() { S.Nothing().ap([1, 2, 3]); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -40,10 +40,10 @@ describe('Just', function() {
   });
 
   it('provides a "chain" method', function() {
-    eq(S.Just([1, 2, 3]).chain.length, 1);
-    eq(S.Just([1, 2, 3]).chain(S.head), S.Just(1));
+    eq(S.Nothing().chain.length, 1);
+    eq(S.Nothing().chain(S.head), S.Nothing());
 
-    throws(function() { S.Just([1, 2, 3]).chain([1, 2, 3]); },
+    throws(function() { S.Nothing().chain(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -51,17 +51,17 @@ describe('Just', function() {
                    '                          ^^^^^^^^\n' +
                    '                             1\n' +
                    '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+                   '1)  null :: Null\n' +
                    '\n' +
                    'The value at position 1 is not a member of ‘Function’.\n'));
-    });
+  });
 
   it('provides a "concat" method', function() {
-    eq(S.Just('foo').concat.length, 1);
-    eq(S.Just('foo').concat(S.Nothing()), S.Just('foo'));
-    eq(S.Just('foo').concat(S.Just('bar')), S.Just('foobar'));
+    eq(S.Nothing().concat.length, 1);
+    eq(S.Nothing().concat(S.Nothing()), S.Nothing());
+    eq(S.Nothing().concat(S.Just('foo')), S.Just('foo'));
 
-    throws(function() { S.Just('foo').concat([1, 2, 3]); },
+    throws(function() { S.Nothing().concat(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -69,35 +69,11 @@ describe('Just', function() {
                    '                                          ^^^^^^^\n' +
                    '                                             1\n' +
                    '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+                   '1)  null :: Null\n' +
                    '\n' +
                    'The value at position 1 is not a member of ‘Maybe a’.\n'));
 
-    throws(function() { S.Just(1).concat(S.Just(0)); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^          ^\n' +
-                   '                                     1\n' +
-                   '\n' +
-                   '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
-
-    throws(function() { S.Just(2).concat(S.Just([1, 2, 3])); },
-           errorEq(TypeError,
-                   'Type-class constraint violation\n' +
-                   '\n' +
-                   'Maybe#concat :: Semigroup a => Maybe a -> Maybe a -> Maybe a\n' +
-                   '                ^^^^^^^^^^^          ^\n' +
-                   '                                     1\n' +
-                   '\n' +
-                   '1)  2 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
-                   '\n' +
-                   '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
-
-    throws(function() { S.Just([1, 2, 3]).concat(S.Just(3)); },
+    throws(function() { S.Nothing().concat(S.Just(1)); },
            errorEq(TypeError,
                    'Type-class constraint violation\n' +
                    '\n' +
@@ -105,39 +81,30 @@ describe('Just', function() {
                    '                ^^^^^^^^^^^                     ^\n' +
                    '                                                1\n' +
                    '\n' +
-                   '1)  3 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
+                   '1)  1 :: Number, FiniteNumber, NonZeroFiniteNumber, Integer, ValidNumber\n' +
                    '\n' +
                    '‘Maybe#concat’ requires ‘a’ to satisfy the Semigroup type-class constraint; the value at position 1 does not.\n'));
-    });
+  });
 
   it('provides an "equals" method', function() {
-    eq(S.Just(42).equals.length, 1);
-    eq(S.Just(42).equals(S.Just(42)), true);
-    eq(S.Just(42).equals(S.Just(43)), false);
-    eq(S.Just(42).equals(S.Nothing()), false);
-    eq(S.Just(42).equals(null), false);
-
-    // Value-based equality:
-    eq(S.Just(0).equals(S.Just(-0)), false);
-    eq(S.Just(-0).equals(S.Just(0)), false);
-    eq(S.Just(NaN).equals(S.Just(NaN)), true);
-    eq(S.Just([1, 2, 3]).equals(S.Just([1, 2, 3])), true);
-    eq(S.Just(new Number(42)).equals(S.Just(new Number(42))), true);
-    eq(S.Just(new Number(42)).equals(42), false);
+    eq(S.Nothing().equals.length, 1);
+    eq(S.Nothing().equals(S.Nothing()), true);
+    eq(S.Nothing().equals(S.Just(42)), false);
+    eq(S.Nothing().equals(null), false);
   });
 
   it('provides an "extend" method', function() {
-    eq(S.Just(42).extend.length, 1);
-    eq(S.Just(42).extend(function(x) { return x.value / 2; }), S.Just(21));
+    eq(S.Nothing().extend.length, 1);
+    eq(S.Nothing().extend(function(x) { return x.value / 2; }), S.Nothing());
 
     // associativity
-    var w = S.Just(42);
+    var w = S.Nothing();
     var f = function(x) { return x.value + 1; };
     var g = function(x) { return x.value * x.value; };
     eq(w.extend(g).extend(f),
        w.extend(function(_w) { return f(_w.extend(g)); }));
 
-    throws(function() { S.Just(42).extend(null); },
+    throws(function() { S.Nothing().extend(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -151,13 +118,11 @@ describe('Just', function() {
   });
 
   it('provides a "filter" method', function() {
-    eq(S.Just(42).filter.length, 1);
-    eq(S.Just(42).filter(R.T), S.Just(42));
-    eq(S.Just(42).filter(R.F), S.Nothing());
-    eq(S.Just(42).filter(function(n) { return n > 0; }), S.Just(42));
-    eq(S.Just(42).filter(function(n) { return n < 0; }), S.Nothing());
+    eq(S.Nothing().filter.length, 1);
+    eq(S.Nothing().filter(R.T), S.Nothing());
+    eq(S.Nothing().filter(R.F), S.Nothing());
 
-    var m = S.Just(-5);
+    var m = S.Nothing();
     var f = function(n) { return n * n; };
     var p = function(n) { return n < 0; };
     var q = function(n) { return n > 0; };
@@ -167,7 +132,7 @@ describe('Just', function() {
     assert(m.map(f).filter(q)
            .equals(m.filter(function(x) { return q(f(x)); }).map(f)));
 
-    throws(function() { S.Just(42).filter(null); },
+    throws(function() { S.Nothing().filter(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -181,10 +146,10 @@ describe('Just', function() {
   });
 
   it('provides a "map" method', function() {
-    eq(S.Just(42).map.length, 1);
-    eq(S.Just(42).map(function(x) { return x / 2; }), S.Just(21));
+    eq(S.Nothing().map.length, 1);
+    eq(S.Nothing().map(function() { return 42; }), S.Nothing());
 
-    throws(function() { S.Just(42).map([1, 2, 3]); },
+    throws(function() { S.Nothing().map(null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -192,16 +157,16 @@ describe('Just', function() {
                    '                        ^^^^^^^^\n' +
                    '                           1\n' +
                    '\n' +
-                   '1)  [1, 2, 3] :: Array Number, Array FiniteNumber, Array NonZeroFiniteNumber, Array Integer, Array ValidNumber\n' +
+                   '1)  null :: Null\n' +
                    '\n' +
                    'The value at position 1 is not a member of ‘Function’.\n'));
   });
 
   it('provides a "reduce" method', function() {
-    eq(S.Just(5).reduce.length, 2);
-    eq(S.Just(5).reduce(function(a, b) { return a + b; }, 10), 15);
+    eq(S.Nothing().reduce.length, 2);
+    eq(S.Nothing().reduce(function(a, b) { return a + b; }, 10), 10);
 
-    throws(function() { S.Just().reduce(null, null); },
+    throws(function() { S.Nothing().reduce(null, null); },
            errorEq(TypeError,
                    'Invalid value\n' +
                    '\n' +
@@ -215,31 +180,31 @@ describe('Just', function() {
   });
 
   it('provides a "sequence" method', function() {
-    eq(S.Just(S.Right(42)).sequence.length, 1);
-    eq(S.Just(S.Right(42)).sequence(S.Either.of), S.Right(S.Just(42)));
+    eq(S.Nothing().sequence.length, 1);
+    eq(S.Nothing().sequence(S.Either.of), S.Right(S.Nothing()));
   });
 
   it('provides a "toBoolean" method', function() {
-    eq(S.Just(42).toBoolean.length, 0);
-    eq(S.Just(42).toBoolean(), true);
+    eq(S.Nothing().toBoolean.length, 0);
+    eq(S.Nothing().toBoolean(), false);
   });
 
   it('provides a "toString" method', function() {
-    eq(S.Just([1, 2, 3]).toString.length, 0);
-    eq(S.Just([1, 2, 3]).toString(), 'Just([1, 2, 3])');
+    eq(S.Nothing().toString.length, 0);
+    eq(S.Nothing().toString(), 'Nothing()');
   });
 
   it('implements Semigroup', function() {
-    var a = S.Just('foo');
-    var b = S.Just('bar');
-    var c = S.Just('baz');
+    var a = S.Nothing();
+    var b = S.Nothing();
+    var c = S.Nothing();
 
     // associativity
     assert(a.concat(b).concat(c).equals(a.concat(b.concat(c))));
   });
 
   it('implements Monoid', function() {
-    var a = S.Just([1, 2, 3]);
+    var a = S.Nothing();
 
     // left identity
     assert(a.empty().concat(a).equals(a));
@@ -249,7 +214,7 @@ describe('Just', function() {
   });
 
   it('implements Functor', function() {
-    var a = S.Just(7);
+    var a = S.Nothing();
     var f = S.inc;
     var g = square;
 
@@ -261,9 +226,9 @@ describe('Just', function() {
   });
 
   it('implements Apply', function() {
-    var a = S.Just(S.inc);
-    var b = S.Just(square);
-    var c = S.Just(7);
+    var a = S.Nothing();
+    var b = S.Nothing();
+    var c = S.Nothing();
 
     // composition
     assert(a.map(function(f) {
@@ -276,8 +241,8 @@ describe('Just', function() {
   });
 
   it('implements Applicative', function() {
-    var a = S.Just(null);
-    var b = S.Just(S.inc);
+    var a = S.Nothing();
+    var b = S.Nothing();
     var f = S.inc;
     var x = 7;
 
@@ -292,7 +257,7 @@ describe('Just', function() {
   });
 
   it('implements Chain', function() {
-    var a = S.Just([[1, 2, 3], [4, 5, 6], [7, 8, 9]]);
+    var a = S.Nothing();
     var f = S.head;
     var g = S.last;
 
@@ -302,7 +267,7 @@ describe('Just', function() {
   });
 
   it('implements Monad', function() {
-    var a = S.Just(null);
+    var a = S.Nothing();
     var f = S.head;
     var x = [1, 2, 3];
 


### PR DESCRIPTION
#185 caused problems for me on OS X, because __test/Either.js__ and __test/either.js__ are considered the same filename.

This pull request introduces __test/Either__ and __test/Maybe__ directories for the benefit of case-insensitive file systems.
